### PR TITLE
Adds and uses seed data for themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ mix deps.compile
 mix ecto.create
 mix ecto.migrate
 npm install
+mix run priv/repo/seeds.exs  # Load seed data
 ```
 
 ## Running the server

--- a/src/dguweb/priv/repo/seeds.exs
+++ b/src/dguweb/priv/repo/seeds.exs
@@ -9,3 +9,86 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias DGUWeb.Repo, as: R 
+alias DGUWeb.Theme, as: T
+
+# Themes ######################################################################
+
+R.delete_all T
+
+R.insert(%T{
+    name: "business-economy",
+    title: "Business and Economy",
+    description: "Small businesses, industry, imports, exports and trade"
+})
+
+R.insert(%T{
+    name: "environment",
+    title: "Environment",
+    description: "Weather, flooding, rivers, air quality, geology and agriculture"
+})
+
+R.insert(%T{
+    name: "mapping",
+    title: "Mapping",
+    description: "Addresses, boundaries, land ownership, aerial photographs, seabed and land terrain"
+})
+
+
+R.insert(%T{
+    name: "crime-justice",
+    title: "Crime and Justice",
+    description: "Courts, police, prisons, offenders, borders and immigration"
+})
+
+
+R.insert(%T{
+    name: "government",
+    title: "Government",
+    description: "Staff numbers and pay, local councillors and department business plans"
+})
+
+
+R.insert(%T{
+    name: "society",
+    title: "Society",
+    description: "Employment, benefits, household finances, poverty and population"
+})
+
+R.insert(%T{
+    name: "defence",
+    title: "Defence",
+    description: "Armed forces, health and safety, search and rescue"
+})
+
+R.insert(%T{
+    name: "government-spending",
+    title: "Government Spending",
+    description: "Includes all payments by government departments over £25,000"
+})
+
+R.insert(%T{
+    name: "towns-cities",
+    title: "Towns and Cities",
+    description: "Includes housing, urban planning, leisure, waste and energy consumption"
+})
+
+R.insert(%T{
+    name: "education",
+    title: "Education",
+    description: "Students, training, qualifications and the National Curriculum"
+})
+
+R.insert(%T{
+    name: "health",
+    title: "Health",
+    description: "Includes smoking, drugs, alcohol, medicine performance and hospitals"
+})
+
+R.insert(%T{
+    name: "transport",
+    title: "Transport",
+    description: "Includes housing, urban planning, leisure, waste and energy consumption"
+})
+

--- a/src/dguweb/test/controllers/theme_controller_test.exs
+++ b/src/dguweb/test/controllers/theme_controller_test.exs
@@ -2,7 +2,7 @@ defmodule DGUWeb.ThemeControllerTest do
   use DGUWeb.ConnCase
 
   alias DGUWeb.Theme
-  @valid_attrs %{}
+  @valid_attrs %{name: "test", title: "test", description: "Description"}
   @invalid_attrs %{}
 
   test "lists all entries on index", %{conn: conn} do
@@ -27,9 +27,9 @@ defmodule DGUWeb.ThemeControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    theme = Repo.insert! %Theme{}
-    conn = get conn, theme_path(conn, :show, theme)
-    assert html_response(conn, 200) =~ "Show theme"
+    theme = Repo.insert! %Theme{name: "scr_test", title: "Test Theme"}
+    conn = get conn, theme_path(conn, :show, theme.name)
+    assert html_response(conn, 200) =~ "Test Theme"
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do
@@ -39,27 +39,27 @@ defmodule DGUWeb.ThemeControllerTest do
   end
 
   test "renders form for editing chosen resource", %{conn: conn} do
-    theme = Repo.insert! %Theme{}
-    conn = get conn, theme_path(conn, :edit, theme)
+    theme = Repo.insert! %Theme{name: "trf_test"}
+    conn = get conn, theme_path(conn, :edit, theme.name)
     assert html_response(conn, 200) =~ "Edit theme"
   end
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    theme = Repo.insert! %Theme{}
-    conn = put conn, theme_path(conn, :update, theme), theme: @valid_attrs
-    assert redirected_to(conn) == theme_path(conn, :show, theme)
+    theme = Repo.insert! (%Theme{} |> Map.merge(@valid_attrs))
+    conn = put conn, theme_path(conn, :update, theme.name), theme: @valid_attrs
+    assert redirected_to(conn) == theme_path(conn, :show, theme.name)
     assert Repo.get_by(Theme, @valid_attrs)
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    theme = Repo.insert! %Theme{}
-    conn = put conn, theme_path(conn, :update, theme), theme: @invalid_attrs
+    theme = Repo.insert! %Theme{name: "dnu_test"}
+    conn = put conn, theme_path(conn, :update, theme.name), theme: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit theme"
   end
 
   test "deletes chosen resource", %{conn: conn} do
-    theme = Repo.insert! %Theme{}
-    conn = delete conn, theme_path(conn, :delete, theme)
+    theme = Repo.insert! %Theme{name: "dcr_test"}
+    conn = delete conn, theme_path(conn, :delete, theme.name)
     assert redirected_to(conn) == theme_path(conn, :index)
     refute Repo.get(Theme, theme.id)
   end

--- a/src/dguweb/web/controllers/page_controller.ex
+++ b/src/dguweb/web/controllers/page_controller.ex
@@ -1,7 +1,9 @@
 defmodule DGUWeb.PageController do
   use DGUWeb.Web, :controller
-
+  alias DGUWeb.Theme 
+  
   def index(conn, _params) do
-    render conn, "index.html"
+    themes = Repo.all(Theme)
+    render conn, "index.html", themes: themes 
   end
 end

--- a/src/dguweb/web/controllers/theme_controller.ex
+++ b/src/dguweb/web/controllers/theme_controller.ex
@@ -45,7 +45,7 @@ defmodule DGUWeb.ThemeController do
       {:ok, theme} ->
         conn
         |> put_flash(:info, "Theme updated successfully.")
-        |> redirect(to: theme_path(conn, :show, theme))
+        |> redirect(to: theme_path(conn, :show, theme.name))
       {:error, changeset} ->
         render(conn, "edit.html", theme: theme, changeset: changeset)
     end

--- a/src/dguweb/web/controllers/theme_controller.ex
+++ b/src/dguweb/web/controllers/theme_controller.ex
@@ -27,18 +27,18 @@ defmodule DGUWeb.ThemeController do
   end
 
   def show(conn, %{"id" => id}) do
-    theme = Repo.get!(Theme, id)
+    theme = Repo.get_by!(Theme, name: id)
     render(conn, "show.html", theme: theme)
   end
 
   def edit(conn, %{"id" => id}) do
-    theme = Repo.get!(Theme, id)
+    theme = Repo.get_by!(Theme, name: id) 
     changeset = Theme.changeset(theme)
     render(conn, "edit.html", theme: theme, changeset: changeset)
   end
 
   def update(conn, %{"id" => id, "theme" => theme_params}) do
-    theme = Repo.get!(Theme, id)
+    theme = Repo.get_by!(Theme, name: id)
     changeset = Theme.changeset(theme, theme_params)
 
     case Repo.update(changeset) do
@@ -52,7 +52,7 @@ defmodule DGUWeb.ThemeController do
   end
 
   def delete(conn, %{"id" => id}) do
-    theme = Repo.get!(Theme, id)
+    theme = Repo.get_by!(Theme, name: id)
 
     # Here we use delete! (with a bang) because we expect
     # it to always work (and if it does not, it will raise).

--- a/src/dguweb/web/templates/layout/app.html.eex
+++ b/src/dguweb/web/templates/layout/app.html.eex
@@ -63,7 +63,7 @@
     <div class="header-wrapper">
       <div class="header-global">
         <div class="header-logo">
-          <a href="" title="" id="logo" class="content">
+          <a href="/" title="" id="logo" class="content">
           <img src="<%= static_path(@conn, "/govuk_template/assets/images/gov.uk_logotype_crown_invert_trans.png?0.18.0") %>" width="35" height="31" alt="">
           </a>
         </div>
@@ -71,7 +71,7 @@
       </div>
       <div class='header-proposition'>
         <div class='content'>
-          <a href='<% page_path(@conn, :index)%>' id='proposition-name'>data.gov.uk</a>
+          <a href='/' id='proposition-name'>data.gov.uk</a>
         </div>
       </div>
     </div>

--- a/src/dguweb/web/templates/page/index.html.eex
+++ b/src/dguweb/web/templates/page/index.html.eex
@@ -20,65 +20,15 @@
 <h1 class="heading-small">Browse by theme</h1>
 <hr/>
 
-<div class="grid-row">
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="/themes/Business%20%26%20Economy">Business and economy</a></h1>
-          <p>Small businesses, industry, imports, exports and trade</p>
-  </div>
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="/themes/Environment">Environment</a></h1>
-          <p>Weather, flooding, rivers, air quality, geology and agriculture</p>
-  </div>
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="/themes/Mapping">Mapping</a></h1>
-          <p>Addresses, boundaries, land ownership, aerial photographs, seabed and land terrain</p>
-  </div>
-</div>
 
-<div class="grid-row">
+<%= for row <- Enum.chunk(@themes, 3) do %>
+  <div class="grid-row">
+  <%= for theme <- row do %>
   <div class="column-one-third">
-         <h1 class="heading-small"><a href="/themes/Crime%20%26%20Justice">Crime and justice</a></h1>
-          <p>Courts, police, prisons, offenders, borders and immigration</p>
+    <h1 class="heading-small"><a href="/themes/<%= theme.name %>"><%= theme.title %></a></h1>
+    <p><%= theme.description %></p>
   </div>
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="/themes/Government">Government</a></h1>
-          <p>Staff numbers and pay, local councillors and department business plans</p>
+  <% end %>
   </div>
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="themes/Society">Society</a></h1>
-          <p>Employment, benefits, household finances, poverty and population</p>
-  </div>
-</div>
-
-
-<div class="grid-row">
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="/themes/Defence">Defence</a></h1>
-          <p>Armed forces, health and safety, search and rescue</p>
-  </div>
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="/themes/Government%20Spending">Government spending</a></h1>
-          <p>Includes all payments by government departments over £25,000</p>
-  </div>
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="/themes/Towns%20%26%20Cities">Towns and cities</a></h1>
-          <p>Includes housing, urban planning, leisure, waste and energy consumption</p>
-  </div>
-</div>
-
-<div class="grid-row">
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="/themes/Education">Education</a></h1>
-          <p>Students, training, qualifications and the National Curriculum</p>
-  </div>
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="/themes/Health">Health</a></h1>
-          <p>Includes smoking, drugs, alcohol, medicine performance and hospitals</p>
-
-  </div>
-  <div class="column-one-third">
-          <h1 class="heading-small"><a href="/themes/Transport">Transport</a></h1>
-          <p>Airports, roads, freight, electric vehicles, parking, buses and footpaths</p>
-  </div>
-</div>
+<% end %>
 

--- a/src/dguweb/web/templates/theme/index.html.eex
+++ b/src/dguweb/web/templates/theme/index.html.eex
@@ -3,18 +3,20 @@
 <table class="table">
   <thead>
     <tr>
-
+      <th>Theme</th>
       <th></th>
     </tr>
   </thead>
   <tbody>
 <%= for theme <- @themes do %>
     <tr>
-
+    <td>
+      <%= theme.title %>
+    </td>
       <td class="text-right">
-        <%= link "Show", to: theme_path(@conn, :show, theme), class: "btn btn-default btn-xs" %>
-        <%= link "Edit", to: theme_path(@conn, :edit, theme), class: "btn btn-default btn-xs" %>
-        <%= link "Delete", to: theme_path(@conn, :delete, theme), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+        <%= link "Show", to: theme_path(@conn, :show, theme.name), class: "btn btn-default btn-xs" %>
+        <%= link "Edit", to: theme_path(@conn, :edit, theme.name), class: "btn btn-default btn-xs" %>
+        <%= link "Delete", to: theme_path(@conn, :delete, theme.name), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
       </td>
     </tr>
 <% end %>

--- a/src/dguweb/web/templates/theme/show.html.eex
+++ b/src/dguweb/web/templates/theme/show.html.eex
@@ -1,8 +1,5 @@
-<h2>Show theme</h2>
 
-<ul>
+<h1 class='heading-xlarge'><%= @theme.title %></h1>
 
-</ul>
-
-<%= link "Edit", to: theme_path(@conn, :edit, @theme) %>
+<%= link "Edit", to: theme_path(@conn, :edit, @theme.name) %>
 <%= link "Back", to: theme_path(@conn, :index) %>


### PR DESCRIPTION
Added a script file (that is hooked up to the DB) that will pre-populate it with some themes.

You should run the following command to pre-load some data into the
database. You can run it as many times as you like, but best not to do this once I add publishers.

```
mix run priv/repo/seeds.exs
```

Hooks up the scaffolding for themes so you can edit/add more although
for themes in particular we probably don't want to allow deletion.

Next PR should include publishing organisations.
