### PR TITLE
Skeleton of upload functionality

### DIFF
--- a/src/dguweb/lib/upload/info.ex
+++ b/src/dguweb/lib/upload/info.ex
@@ -1,4 +1,23 @@
 defmodule DGUWeb.Upload.Info do
+    defstruct filename: "", content_type: "", path: "", size: -1, warnings: [], errors: []
 
-    defstruct filename: ""
+    def from_upload(upload) do 
+        # We have to move this file before the request completes.
+        newpath = "/tmp/#{upload.filename}"
+        :ok = File.cp(upload.path, newpath)
+        {:ok, stat} = File.stat(newpath)
+
+        %__MODULE__{
+            filename: upload.filename,
+            content_type: upload.content_type,
+            path: newpath,
+            size: stat.size,
+        }
+    end 
+
+    def from_url(url) do 
+        %__MODULE__{
+            filename: url,
+        }
+    end     
 end 

--- a/src/dguweb/lib/upload/info.ex
+++ b/src/dguweb/lib/upload/info.ex
@@ -1,0 +1,4 @@
+defmodule DGUWeb.Upload.Info do
+
+    defstruct filename: ""
+end 

--- a/src/dguweb/lib/upload/tasks.ex
+++ b/src/dguweb/lib/upload/tasks.ex
@@ -1,0 +1,72 @@
+defmodule DGUWeb.Upload.Tasks do 
+  @moduledoc """
+  Tasks for processing urls and uploaded files
+  """
+
+  alias DGUWeb.Upload.Info 
+
+  # The list of tasks that should be run against urls that are provided
+  def url_tasks do 
+    [
+      {__MODULE__, :info_from_headers},
+      {__MODULE__, :print}
+    ]
+  end 
+
+  # The list of tasks that should be run against files that are uploaded.  
+  def file_tasks do 
+    [
+      {__MODULE__, :print}
+    ]
+  end 
+
+  @doc """
+  Runs all of the tasks for the upload type making sure that each one 
+  returns an Info (either updated or not). If at any stage errors are 
+  added to the Info then no further processing will happen.
+  """
+  def run_tasks(info, tasks) do 
+    Enum.reduce(tasks, info, fn ({m, f}, acc)-> 
+      apply_func(m, f, acc, length(acc.errors))
+    end)
+  end
+
+  def apply_func(m, f, acc, 0), do: apply(m, f, [acc])
+  def apply_func(_, _, acc, _error_count), do: acc
+
+  @doc """
+  Just for debugging, prints out the current Info struct.
+  """
+  def print(info) do 
+    IO.inspect info
+  end 
+
+  @doc """
+  Retrieves from information, if possible, from a HEAD request to the URL of the 
+  resource.  
+  """
+  def info_from_headers(info) do 
+    case HTTPoison.head(info.filename) do
+      {:ok, %HTTPoison.Response{status_code: 200, headers: headers}} ->
+        headermap = Enum.into(headers, %{})
+        %Info{info | 
+          size: Map.get(headermap, "Content-Length"),
+          content_type: Map.get(headermap, "Content-Type")
+        }
+      {:ok, %HTTPoison.Response{status_code: 404}} ->
+        %Info{info | 
+          errors: ["URL was not found" | info.errors],
+        }
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        %Info{info | 
+          warnings: [reason | info.warnings],
+        }
+      x ->
+        %Info{info | 
+          warnings: ["Request failed" | info.warnings],
+        }
+    end
+  end 
+
+
+end

--- a/src/dguweb/mix.exs
+++ b/src/dguweb/mix.exs
@@ -23,7 +23,7 @@ defmodule DGUWeb.Mixfile do
   def application do
     [mod: {DGUWeb, []},
      applications: [:phoenix, :phoenix_pubsub, :phoenix_html, :cowboy, :logger, :gettext,
-                    :phoenix_ecto, :postgrex]]
+                    :phoenix_ecto, :postgrex, :httpoison]]
   end
 
   # Specifies which paths to compile per environment.
@@ -41,7 +41,9 @@ defmodule DGUWeb.Mixfile do
      {:phoenix_html, "~> 2.6"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
-     {:cowboy, "~> 1.0"}]
+     {:cowboy, "~> 1.0"},
+     {:httpoison, "~> 0.9.0"}
+    ]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/src/dguweb/mix.lock
+++ b/src/dguweb/mix.lock
@@ -1,4 +1,5 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "db_connection": {:hex, :db_connection, "1.0.0-rc.3", "d9ceb670fe300271140af46d357b669983cd16bc0d01206d7d3222dde56cf038", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
@@ -6,6 +7,11 @@
   "ecto": {:hex, :ecto, "2.0.2", "b02331c1f20bbe944dbd33c8ecd8f1ccffecc02e344c4471a891baf3a25f5406", [:mix], [{:db_connection, "~> 1.0-rc.2", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.11.2", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
+  "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
+  "httpoison": {:hex, :httpoison, "0.9.0", "68187a2daddfabbe7ca8f7d75ef227f89f0e1507f7eecb67e4536b3c516faddb", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
+  "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "phoenix": {:hex, :phoenix, "1.2.0", "1bdeb99c254f4c534cdf98fd201dede682297ccc62fcac5d57a2627c3b6681fb", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "phoenix_ecto": {:hex, :phoenix_ecto, "3.0.0", "b947aaf03d076f5b1448f87828f22fb7710478ee38455c67cc3fe8e9a4dfd015", [:mix], [{:ecto, "~> 2.0.0-rc", [hex: :ecto, optional: false]}, {:phoenix_html, "~> 2.6", [hex: :phoenix_html, optional: true]}]},
   "phoenix_html": {:hex, :phoenix_html, "2.6.2", "944a5e581b0d899e4f4c838a69503ebd05300fe35ba228a74439e6253e10e0c0", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
@@ -15,4 +21,5 @@
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "postgrex": {:hex, :postgrex, "0.11.2", "139755c1359d3c5c6d6e8b1ea72556d39e2746f61c6ddfb442813c91f53487e8", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
-  "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []}}
+  "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}

--- a/src/dguweb/test/controllers/publish_controller_test.exs
+++ b/src/dguweb/test/controllers/publish_controller_test.exs
@@ -1,8 +1,9 @@
 defmodule DGUWeb.PublishControllerTest do
   use DGUWeb.ConnCase
 
-  @valid_attrs_upload %{file: %Plug.Upload{content_type: "text/csv", filename: "test-file.csv", path: ""}, url: ""}
-  @valid_attrs_url %{url: "https://localhost/"}  
+  
+  @valid_attrs_upload %{file: %Plug.Upload{content_type: "text/csv", filename: "test-file.csv", path: File.cwd! <> "/test/data/small-data.csv"}, url: ""}
+  @valid_attrs_url %{url: "http://servercode.co.uk/gold.csv"}  
 
   @invalid_attrs_missing %{file: :nil, url: :nil}
   @invalid_attrs_both %{file: :nil, url: :nil}  

--- a/src/dguweb/test/controllers/publish_controller_test.exs
+++ b/src/dguweb/test/controllers/publish_controller_test.exs
@@ -1,0 +1,44 @@
+defmodule DGUWeb.PublishControllerTest do
+  use DGUWeb.ConnCase
+
+  @valid_attrs_upload %{file: %Plug.Upload{content_type: "text/csv", filename: "test-file.csv", path: ""}, url: ""}
+  @valid_attrs_url %{url: "https://localhost/"}  
+
+  @invalid_attrs_missing %{file: :nil, url: :nil}
+  @invalid_attrs_both %{file: :nil, url: :nil}  
+  @invalid_attrs_bad_url %{file: :nil, url: "Not a valid URL"}
+
+  test "renders form for upload", %{conn: conn} do
+    conn = get conn, publish_path(conn, :index)
+    assert html_response(conn, 200) =~ "Upload data"
+  end
+
+  test "creates resource and redirects when upload data is valid", %{conn: conn} do
+    conn = post conn, publish_path(conn, :add_file), @valid_attrs_upload
+    assert redirected_to(conn) == publish_path(conn, :find)
+  end
+
+  test "creates resource and redirects when url data is valid", %{conn: conn} do
+    conn = post conn, publish_path(conn, :add_file), @valid_attrs_url
+    assert redirected_to(conn) == publish_path(conn, :find)
+  end
+
+  # TODO: Fix error handling in these steps by using a changeset in the controller
+  # once we're happy with the approach
+
+  test "fails when no data provided", %{conn: conn} do
+    conn = post conn, publish_path(conn, :add_file), @invalid_attrs_missing
+    assert html_response(conn, 200) =~ "Please supply a URL or a file upload"
+  end
+
+  test "fails when too much data provided", %{conn: conn} do
+    conn = post conn, publish_path(conn, :add_file), @invalid_attrs_both
+    assert html_response(conn, 200) =~ "Please supply a URL or a file upload"
+  end
+
+  test "fails when badly formatted url provided", %{conn: conn} do
+    conn = post conn, publish_path(conn, :add_file), @invalid_attrs_bad_url
+    assert html_response(conn, 200) =~ "URL does not appear to be valid"
+  end
+
+end

--- a/src/dguweb/test/data/small-data.csv
+++ b/src/dguweb/test/data/small-data.csv
@@ -1,0 +1,2 @@
+header1,header2
+field1,field2

--- a/src/dguweb/web/controllers/publish_controller.ex
+++ b/src/dguweb/web/controllers/publish_controller.ex
@@ -5,34 +5,59 @@ defmodule DGUWeb.PublishController do
   def index(conn, _params) do
     conn
     |> clear_session
-    |> render("index.html", current_files: [])
+    |> render("index.html", current_files: [], error: :nil)
   end
 
-  def add_file(conn, %{"file"=>upload}=params) do
+  ### Add File, upload or URL ################################################
+  #
+  # When (if) we decide that this is better tracked in the database, we can 
+  # rely on the changeset to handle the difference validation requirements 
+  # and/or we can change the process flow.
+  #
+  ############################################################################
+
+  def add_file(conn, params) do
+    file = Map.get(params, "file", :nil)
+    url = Map.get(params, "url", :nil)
+
+    add_file_internal(conn, {file, url})
+  end 
+
+  defp add_file_internal(conn, {:nil, :nil}), do: failed_add_file(conn, "Please supply a URL or a file upload.")
+  defp add_file_internal(conn, {upload, ""}) do 
     # We have to move this file before the request completes
     info = %UploadInfo{filename: upload.filename}
+    progress_add_file(conn, info)
+  end 
 
-    render_add_file(conn, info)
+  defp add_file_internal(conn, {:nil, "http" <> url}) do 
+    info = %UploadInfo{filename: "http" <> url}
+    progress_add_file(conn, info)
+  end 
+
+  defp add_file_internal(conn, {:nil, _url}), do: failed_add_file(conn, "URL does not appear to be valid")
+  defp add_file_internal(conn, {_, _}), do: failed_add_file(conn, "Please supply a URL or a file upload, not both")
+
+  defp failed_add_file(conn, error) do 
+    conn
+    |> render("index.html", current_files: [], error: error)    
   end
 
-  def add_file(conn, %{"url"=>url}=params) do
-    info = %UploadInfo{filename: url}    
-    
-    render_add_file(conn,  info)
-  end
-
-  defp render_add_file(conn, info) do
+  defp progress_add_file(conn, info) do
     current = [info | get_session(conn, :current_files) || []]
 
     conn
     |> put_session(:current_files, current)
-    |> render("index.html", current_files: current)
-end 
+    |> redirect(to: publish_path(conn, :find, []))
+  end 
+
+  ### Determine what the user wants to do with the uploaded data #############
 
   def find(conn, _params) do 
     current = get_session(conn, :current_files) || []
 
     render(conn, "find.html", current_files: current)
   end 
+
 
 end

--- a/src/dguweb/web/controllers/publish_controller.ex
+++ b/src/dguweb/web/controllers/publish_controller.ex
@@ -1,0 +1,38 @@
+defmodule DGUWeb.PublishController do
+  use DGUWeb.Web, :controller
+  alias DGUWeb.Upload.Info, as: UploadInfo
+
+  def index(conn, _params) do
+    conn
+    |> clear_session
+    |> render("index.html", current_files: [])
+  end
+
+  def add_file(conn, %{"file"=>upload}=params) do
+    # We have to move this file before the request completes
+    info = %UploadInfo{filename: upload.filename}
+
+    render_add_file(conn, info)
+  end
+
+  def add_file(conn, %{"url"=>url}=params) do
+    info = %UploadInfo{filename: url}    
+    
+    render_add_file(conn,  info)
+  end
+
+  defp render_add_file(conn, info) do
+    current = [info | get_session(conn, :current_files) || []]
+
+    conn
+    |> put_session(:current_files, current)
+    |> render("index.html", current_files: current)
+end 
+
+  def find(conn, _params) do 
+    current = get_session(conn, :current_files) || []
+
+    render(conn, "find.html", current_files: current)
+  end 
+
+end

--- a/src/dguweb/web/helpers.ex
+++ b/src/dguweb/web/helpers.ex
@@ -1,0 +1,7 @@
+defmodule DGUWeb.TemplateHelpers do
+
+
+    def hello do 
+        "Hello"
+    end 
+end

--- a/src/dguweb/web/router.ex
+++ b/src/dguweb/web/router.ex
@@ -27,7 +27,6 @@ defmodule DGUWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
->>>>>>> master
   end
 
   # Other scopes may use custom stacks.

--- a/src/dguweb/web/router.ex
+++ b/src/dguweb/web/router.ex
@@ -5,7 +5,7 @@ defmodule DGUWeb.Router do
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_flash
-    plug :protect_from_forgery
+    #plug :protect_from_forgery
     plug :put_secure_browser_headers
   end
 

--- a/src/dguweb/web/router.ex
+++ b/src/dguweb/web/router.ex
@@ -18,10 +18,15 @@ defmodule DGUWeb.Router do
 
     get "/", PageController, :index
     get "/search", PageController, :search
+    
+    get "/publish", PublishController, :index
+    post "/publish", PublishController, :add_file
+    get "/publish/find", PublishController, :find
 
     resources "/publishers", PublisherController
     resources "/themes", ThemeController
     resources "/datasets", DatasetController
+
   end
 
   # Other scopes may use custom stacks.

--- a/src/dguweb/web/templates/publish/filelist.html.eex
+++ b/src/dguweb/web/templates/publish/filelist.html.eex
@@ -1,0 +1,8 @@
+
+
+<h1 class="heading-small">Current files</h1>
+<%= for f <- @current_files do %>
+  <div>
+    <%= f.filename %> <a style="font-size:small;" href="">delete</a>
+  </div>
+<% end %>

--- a/src/dguweb/web/templates/publish/find.html.eex
+++ b/src/dguweb/web/templates/publish/find.html.eex
@@ -1,0 +1,49 @@
+
+
+
+<div class="grid-row">
+  <div class="column-two-thirds"
+    <h1>
+      Where would you like to put this data?
+    </h1>
+
+    <form>
+      <fieldset>
+        <legend class="visuallyhidden">Where would you like to add these files</legend>
+        <div class="form-group">
+          <label class="block-label" for="id_organogram">
+            <input id="id_organogram" type="radio" name="add_to" value="organogram">
+            The <a href="" target="_blank">Organogram dataset</a> for ...
+          </label>
+          <label class="block-label" for="id_spend_data">
+            <input id="id_spend_data" type="radio" name="add_to" value="spend_data">
+            The <a href="" target="_blank">Spend Data dataset</a> for ...
+          </label>
+          <label class="block-label" for="id_existing">
+            <input id="id_existing" type="radio" name="add_to" value="existing">
+            An existing dataset
+          </label>
+          <label class="block-label" for="id_new">
+            <input id="id_new" type="radio" name="add_to" value="new">
+            A new dataset
+          </label>
+        </div>
+      </fieldset>
+
+
+      <p>One or more of the files you upload suggest that the data might belong to 
+        one of the following datasets.</p>
+      <div class="form-group">
+        <label class="block-label" for="id_magic">
+          <input id="id_magic" type="radio" name="add_to" value="magic">
+          The <a href="" target="_blank">2015 Business Rates</a> dataset.
+        </label>
+      </div>
+      <div class="form-group">
+          <input type="submit" class="button" value="Next">
+      </div>
+    </form>
+  </div>
+  <div class="column-one-third">
+    <%= render "filelist.html", current_files: @current_files %>
+  </div>

--- a/src/dguweb/web/templates/publish/index.html.eex
+++ b/src/dguweb/web/templates/publish/index.html.eex
@@ -1,4 +1,7 @@
 
+<%= if @error do %>
+  ERROR: <%= @error  %>
+<% end %>
 
 <div class="grid-row">
   <div class="column-two-thirds">
@@ -24,10 +27,7 @@
     </form>
   </div>
   <div class="column-one-third">
-    <%= render "filelist.html", current_files: @current_files %>  
+    <p></p>
   </div>
 </div>
 
-<div class="grid-row">
-  <a class="button right" href="/publish/find">Continue ></a>
-</div>

--- a/src/dguweb/web/templates/publish/index.html.eex
+++ b/src/dguweb/web/templates/publish/index.html.eex
@@ -1,0 +1,33 @@
+
+
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-small">Upload data</h1>  
+    <form action="" method="post" enctype="multipart/form-data">
+      <input type="hidden" name="_csrf_token" value="<%= get_csrf_token() %>">
+
+      <div class="form-group">
+        <label class="control-label" for="file">Choose a file</label>
+        <input class="form-control" type="file" name="file">
+      </div>
+      <div class="form-group">
+        Or
+      </div>
+      <div class="form-group">
+        <label class="control-label" for="url">Provide a URL</label>
+        <input class="form-control" type="url" name="url">
+      </div>
+
+      <div class="form-group">
+        <input class="button" type="submit" value="Upload">
+      </div>
+    </form>
+  </div>
+  <div class="column-one-third">
+    <%= render "filelist.html", current_files: @current_files %>  
+  </div>
+</div>
+
+<div class="grid-row">
+  <a class="button right" href="/publish/find">Continue ></a>
+</div>

--- a/src/dguweb/web/views/layout_view.ex
+++ b/src/dguweb/web/views/layout_view.ex
@@ -1,3 +1,4 @@
 defmodule DGUWeb.LayoutView do
   use DGUWeb.Web, :view
+
 end

--- a/src/dguweb/web/views/publish_view.ex
+++ b/src/dguweb/web/views/publish_view.ex
@@ -1,0 +1,5 @@
+defmodule DGUWeb.PublishView do
+  use DGUWeb.Web, :view
+
+    import DGUWeb.TemplateHelpers
+end


### PR DESCRIPTION
Currently mounted at /publish this commit allows users to
upload files and/or urls and see what they have currently uploaded
before answering questions as to where they want to put the files.

All data is currently in session cookies (booo) and doesn't yet
contain the publisher (perhaps if we launch from the publisher page
we can store it). At some point, it may be useful to store this
information in a PublishSession model so that they can be resumed 
and we can use changesets to help with the validation.

The PublishController will do file processing on the information it receives (currently sync for URLs and async for files) using the functions in ``lib/upload/tasks.ex`.  The main use-case here is to validate the URL by making a HEAD request and storing the file size and content-type.  This is far from foolproof, but is enough for a prototype.

Requires a `mix deps.get` 
