### PR TITLE
Allows users to belong to publishers with a role.

### DIFF
--- a/src/dguweb/priv/repo/migrations/20160809142139_create_publisher_user.exs
+++ b/src/dguweb/priv/repo/migrations/20160809142139_create_publisher_user.exs
@@ -1,0 +1,12 @@
+defmodule DGUWeb.Repo.Migrations.CreatePublisherUser do
+  use Ecto.Migration
+
+  def change do
+    create table(:publisher_user) do
+      add :user_id, references(:users)
+      add :publisher_id, references(:publishers)
+      add :role, :string 
+    end
+
+  end
+end

--- a/src/dguweb/priv/repo/seeds.exs
+++ b/src/dguweb/priv/repo/seeds.exs
@@ -13,6 +13,7 @@
 alias DGUWeb.Repo, as: R 
 alias DGUWeb.Theme, as: T
 alias DGUWeb.Publisher, as: P 
+alias DGUWeb.PublisherUser, as: PU
 
 # Themes ######################################################################
 
@@ -96,9 +97,10 @@ R.insert(%T{
 
 # Themes ######################################################################
 
+R.delete_all PU
 R.delete_all P
 
-R.insert(%P{
+cabinet_office = R.insert(%P{
     name: "cabinet-office",
     title: "Cabinet Office",
     description: "The Cabinet Office supports the Prime Minister and Deputy Prime Minister, and ensure the effective running of government. We are also the corporate headquarters for government, in partnership with HM Treasury, and we take the lead in certain critical policy areas. CO is a ministerial department, supported by 18 agencies and public bodies",
@@ -108,7 +110,7 @@ R.insert(%P{
     closed: false, 
 })
 
-R.insert(%P{
+defra = R.insert(%P{
     name: "department-for-environment-food-rural-affairs",
     title: "Department for Environment, Food and Rural Affairs",
     description: "We are the UK government department responsible for policy and regulations on environmental, food and rural issues. Our priorities are to grow the rural economy, improve the environment and safeguard animal and plant health. Defra is a ministerial department, supported by 38 agencies and public bodies.",
@@ -118,7 +120,7 @@ R.insert(%P{
     closed: false, 
 })
 
-R.insert(%P{
+dft = R.insert(%P{
     name: "department-for-transport",
     title: "Department for Transport",
     description: "We work with our agencies and partners to support the transport network that helps the UK’s businesses and gets people and goods travelling around the country. We plan and invest in transport infrastructure to keep the UK on the move. DFT is a ministerial department, supported by 22 agencies and public bodies.",

--- a/src/dguweb/test/controllers/session_controller_test.exs
+++ b/src/dguweb/test/controllers/session_controller_test.exs
@@ -22,7 +22,7 @@ defmodule DGUWeb.SessionControllerTest do
     assert redirected_to(conn) == "/"
 
     conn = post conn, session_path(conn, :login), session: %{username: "bob", password: "Password"}
-    assert redirected_to(conn) == "/"
+    assert redirected_to(conn) == "/user"
 
     conn = get conn, "/"
     assert html_response(conn, 200) =~ "Sign out"
@@ -46,7 +46,7 @@ defmodule DGUWeb.SessionControllerTest do
     assert redirected_to(conn) == "/"
 
     conn = post conn, session_path(conn, :login), session: %{username: "bob", password: "Password"}
-    assert redirected_to(conn) == "/"
+    assert redirected_to(conn) == "/user"
 
     conn = get conn, session_path(conn, :logout)
     assert redirected_to(conn) == "/"

--- a/src/dguweb/test/controllers/user_controller_test.exs
+++ b/src/dguweb/test/controllers/user_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule DGUWeb.UserControllerTest do
+  use DGUWeb.ConnCase
+
+  alias DGUWeb.{User, Publisher, PublisherUser}
+
+
+  @valid_attrs %{username: "bob", email: "bob@localhost.local", password: "Password"}
+
+  test "valid user can be in ", %{conn: conn} do 
+    # Create a user using registration
+    conn = post conn, session_path(conn, :create), user: @valid_attrs
+    assert redirected_to(conn) == "/"
+
+    # Get a reference so we can fake add them to a publisher 
+    user = Repo.get_by!(User, username: "bob")
+    assert user
+
+    {:ok, publisher} = Repo.insert(%Publisher{
+        name: "cabinet-office", title: "Cabinet Office", url: "http://..."
+    })
+
+    {:ok, pu} = Repo.insert(%PublisherUser{user_id: user.id, publisher_id: publisher.id, role: "admin"})
+    IO.inspect pu 
+    
+    # Login and then check that our newly added org is on the page
+    conn = post conn, session_path(conn, :login), session: @valid_attrs
+    assert redirected_to(conn) == "/user"
+
+    conn = get conn, user_path(conn, :index)
+    assert html_response(conn, 200) =~ "Cabinet Office" 
+    assert html_response(conn, 200) =~ "admin" 
+  end 
+
+
+end 

--- a/src/dguweb/test/controllers/user_controller_test.exs
+++ b/src/dguweb/test/controllers/user_controller_test.exs
@@ -20,7 +20,6 @@ defmodule DGUWeb.UserControllerTest do
     })
 
     {:ok, pu} = Repo.insert(%PublisherUser{user_id: user.id, publisher_id: publisher.id, role: "admin"})
-    IO.inspect pu 
     
     # Login and then check that our newly added org is on the page
     conn = post conn, session_path(conn, :login), session: @valid_attrs
@@ -30,6 +29,5 @@ defmodule DGUWeb.UserControllerTest do
     assert html_response(conn, 200) =~ "Cabinet Office" 
     assert html_response(conn, 200) =~ "admin" 
   end 
-
 
 end 

--- a/src/dguweb/test/models/publisher_user_test.exs
+++ b/src/dguweb/test/models/publisher_user_test.exs
@@ -1,0 +1,18 @@
+defmodule DGUWeb.PublisherUserTest do
+  use DGUWeb.ModelCase
+
+  alias DGUWeb.PublisherUser
+
+  @valid_attrs %{publisher_id: 42, user_id: 42}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = PublisherUser.changeset(%PublisherUser{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = PublisherUser.changeset(%PublisherUser{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/src/dguweb/web/controllers/publisher_controller.ex
+++ b/src/dguweb/web/controllers/publisher_controller.ex
@@ -5,6 +5,7 @@ defmodule DGUWeb.PublisherController do
 
   def index(conn, _params) do
     publishers = Repo.all(Publisher)
+
     render(conn, "index.html", publishers: publishers)
   end
 

--- a/src/dguweb/web/controllers/session_controller.ex
+++ b/src/dguweb/web/controllers/session_controller.ex
@@ -32,7 +32,7 @@ defmodule DGUWeb.SessionController do
         conn
         |> put_session(:current_user, user.id)
         |> put_flash(:info, "Logged in")
-        |> redirect(to: "/")
+        |> redirect(to: "/user")
       :error ->
         conn
         |> put_flash(:info, "Wrong email or password")

--- a/src/dguweb/web/controllers/user_controller.ex
+++ b/src/dguweb/web/controllers/user_controller.ex
@@ -1,0 +1,17 @@
+defmodule DGUWeb.UserController do
+  use DGUWeb.Web, :controller
+  
+  alias DGUWeb.User
+
+  def index(conn, _params) do
+    user = conn |> DGUWeb.Session.current_user     
+    do_index(conn, user)
+  end 
+
+  defp do_index(conn, nil), do: redirect(conn, to: "/")
+  defp do_index(conn, user) do 
+    userpubs = DGUWeb.User.publishers(user)
+    render(conn, "index.html", publishers: userpubs)
+  end
+
+end

--- a/src/dguweb/web/helpers.ex
+++ b/src/dguweb/web/helpers.ex
@@ -1,7 +1,3 @@
 defmodule DGUWeb.TemplateHelpers do
 
-
-    def hello do 
-        "Hello"
-    end 
 end

--- a/src/dguweb/web/models/publisher.ex
+++ b/src/dguweb/web/models/publisher.ex
@@ -21,6 +21,8 @@ defmodule DGUWeb.Publisher do
     field :contact_email, :string
     field :contact_phone, :string
 
+    many_to_many :users, DGUWeb.User, join_through: DGUWeb.PublisherUser
+
     timestamps()
   end
 

--- a/src/dguweb/web/models/publisher_user.ex
+++ b/src/dguweb/web/models/publisher_user.ex
@@ -1,0 +1,18 @@
+defmodule DGUWeb.PublisherUser do
+  use DGUWeb.Web, :model
+
+  schema "publisher_user" do
+    field :user_id, :integer
+    field :publisher_id, :integer
+    field :role, :string, default: "member"
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:user_id, :publisher_id, :role])
+    |> validate_required([:user_id, :publisher_id, :role])
+  end
+end

--- a/src/dguweb/web/models/user.ex
+++ b/src/dguweb/web/models/user.ex
@@ -1,14 +1,41 @@
 defmodule DGUWeb.User do
   use DGUWeb.Web, :model
 
+  alias DGUWeb.Repo
+  alias DGUWeb.PublisherUser
+
   schema "users" do
     field :username, :string
     field :email, :string
     field :password, :string, virtual: true
-
     field :crypted_password, :string
+
+    many_to_many :publisher, DGUWeb.Publisher, join_through: PublisherUser
+
     timestamps()
   end
+
+  @doc """
+  Retrieves the publishers that the given user is a member of. Because we want the role 
+  field in the join table however, we need to also map them separately to the memberships 
+  so we query the join table as well.  One day I hope this is fixed to allow the fields in 
+  the join table to be retrieved as part of the same call.
+  """
+  def publishers(user) do 
+      publishers = Repo.all assoc(user, :publisher)
+      memberships = Repo.all(from(p in PublisherUser, where: p.user_id == ^user.id))
+
+      member_map = memberships 
+      |> Enum.map(fn x ->   
+          {x.publisher_id, x.role}
+      end)
+      |> Enum.into(%{})
+
+      publishers
+      |> Enum.map( fn p -> 
+        {p, Map.get(member_map, p.id)}
+      end)
+  end 
 
   @doc """
   Builds a changeset based on the `struct` and `params`.

--- a/src/dguweb/web/router.ex
+++ b/src/dguweb/web/router.ex
@@ -27,6 +27,8 @@ defmodule DGUWeb.Router do
     get    "/login",  SessionController, :login_view
     post   "/login",  SessionController, :login
     get "/logout", SessionController, :logout
+
+    get "/user", UserController, :index
   end
 
 

--- a/src/dguweb/web/templates/user/index.html.eex
+++ b/src/dguweb/web/templates/user/index.html.eex
@@ -1,0 +1,15 @@
+
+<h1 class="heading-medium">My publishers</h1>
+
+<%= if @publishers == [] do %>
+    <p>You are not a member of any publisher</p>
+<% end %>
+
+<ul>
+<%= for {pub, role} <- @publishers do %>
+    <li>
+    <%= link pub.title, to: publisher_path(@conn, :show, pub.name) %>
+    (<%= role %>)
+    </li>
+<% end %>
+</ul>

--- a/src/dguweb/web/templates/user/index.html.eex
+++ b/src/dguweb/web/templates/user/index.html.eex
@@ -1,5 +1,5 @@
 
-<h1 class="heading-medium">My publishers</h1>
+<h1 class="heading-xlarge">My publishers</h1>
 
 <%= if @publishers == [] do %>
     <p>You are not a member of any publisher</p>

--- a/src/dguweb/web/views/user_view.ex
+++ b/src/dguweb/web/views/user_view.ex
@@ -1,0 +1,3 @@
+defmodule DGUWeb.UserView do
+  use DGUWeb.Web, :view
+end


### PR DESCRIPTION
The many_to_many is messy because it's not really complete in Ecto, it's
too complex to get the extra columns (in this case :role) from the join
table so I have hacked around it in the user model.
