### PR TITLE
Seeds the database with some templated datasets for the seeded

### DIFF
--- a/src/dguweb/config/config.exs
+++ b/src/dguweb/config/config.exs
@@ -30,6 +30,7 @@ config :ex_admin,
     DGUWeb.ExAdmin.Dashboard,
     DGUWeb.ExAdmin.Publisher,
     DGUWeb.ExAdmin.Dataset,
+    DGUWeb.ExAdmin.DataFile,
   ]
 
 # Import environment specific config. This must remain at the bottom

--- a/src/dguweb/priv/repo/migrations/20160810112555_create_data_file.exs
+++ b/src/dguweb/priv/repo/migrations/20160810112555_create_data_file.exs
@@ -1,0 +1,17 @@
+defmodule DGUWeb.Repo.Migrations.CreateDataFile do
+  use Ecto.Migration
+
+  def change do
+    create table(:datafiles) do
+      add :name, :string
+      add :description, :text
+      add :url, :text
+      add :format, :string
+      add :dataset_id, references(:datasets, on_delete: :nothing)
+
+      timestamps()
+    end
+    create index(:datafiles, [:dataset_id])
+
+  end
+end

--- a/src/dguweb/priv/repo/seeds.exs
+++ b/src/dguweb/priv/repo/seeds.exs
@@ -12,6 +12,8 @@
 
 alias DGUWeb.Repo, as: R 
 alias DGUWeb.Theme, as: T
+alias DGUWeb.Dataset, as: D 
+alias DGUWeb.DataFile, as: DF 
 alias DGUWeb.Publisher, as: P 
 alias DGUWeb.PublisherUser, as: PU
 
@@ -95,12 +97,14 @@ R.insert(%T{
 })
 
 
-# Themes ######################################################################
+# Publishers ######################################################################
 
 R.delete_all PU
+R.delete_all DF
+R.delete_all D
 R.delete_all P
 
-cabinet_office = R.insert(%P{
+cabinet_office = R.insert!(%P{
     name: "cabinet-office",
     title: "Cabinet Office",
     description: "The Cabinet Office supports the Prime Minister and Deputy Prime Minister, and ensure the effective running of government. We are also the corporate headquarters for government, in partnership with HM Treasury, and we take the lead in certain critical policy areas. CO is a ministerial department, supported by 18 agencies and public bodies",
@@ -110,7 +114,7 @@ cabinet_office = R.insert(%P{
     closed: false, 
 })
 
-defra = R.insert(%P{
+defra = R.insert!(%P{
     name: "department-for-environment-food-rural-affairs",
     title: "Department for Environment, Food and Rural Affairs",
     description: "We are the UK government department responsible for policy and regulations on environmental, food and rural issues. Our priorities are to grow the rural economy, improve the environment and safeguard animal and plant health. Defra is a ministerial department, supported by 38 agencies and public bodies.",
@@ -120,7 +124,7 @@ defra = R.insert(%P{
     closed: false, 
 })
 
-dft = R.insert(%P{
+dft = R.insert!(%P{
     name: "department-for-transport",
     title: "Department for Transport",
     description: "We work with our agencies and partners to support the transport network that helps the UK’s businesses and gets people and goods travelling around the country. We plan and invest in transport infrastructure to keep the UK on the move. DFT is a ministerial department, supported by 22 agencies and public bodies.",
@@ -130,3 +134,88 @@ dft = R.insert(%P{
     closed: false, 
 })
 
+# Datasets ######################################################################
+
+co_organogram = R.insert!(%D{
+    name: "co-organogram",
+    title: "Organogram",
+    publisher_id: cabinet_office.id 
+})
+
+R.insert!(%DF{
+    name: "Organogram data, August 2016",
+    description: "This file contains the spending data for ...",
+    url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
+    format: "CSV",
+    dataset_id: co_organogram.id 
+})
+
+defra_organogram = R.insert!(%D{
+    name: "defra-organogram",
+    title: "Organogram",
+    publisher_id: defra.id 
+})
+
+R.insert!(%DF{
+    name: "Organogram data, August 2016",
+    description: "This file contains the spending data for ...",
+    url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
+    format: "CSV",
+    dataset_id: defra_organogram.id 
+})
+
+dft_organogram = R.insert!(%D{
+    name: "dft-organogram",
+    title: "Organogram",
+    publisher_id: dft.id 
+})
+
+R.insert!(%DF{
+    name: "Organogram data, July 2016",
+    description: "This file contains the spending data for ...",
+    url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
+    format: "CSV",
+    dataset_id: dft_organogram.id 
+})
+
+co_spending = R.insert!(%D{
+    name: "co-spending",
+    title: "Spending",
+    publisher_id: cabinet_office.id 
+})
+
+R.insert!(%DF{
+    name: "Spending August 2016",
+    description: "This file contains the spending data for ...",
+    url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
+    format: "CSV",
+    dataset_id: co_spending.id 
+})
+
+defra_spending = R.insert!(%D{
+    name: "defra-spending",
+    title: "Spending",
+    publisher_id: defra.id 
+})
+
+R.insert!(%DF{
+    name: "Spending July 2016",
+    description: "This file contains the spending data for ...",
+    url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
+    format: "CSV",
+    dataset_id: defra_spending.id 
+})
+
+dft_spending = R.insert!(%D{
+    name: "dft-spending",
+    title: "Spending",
+    publisher_id: dft.id 
+})
+
+R.insert!(%DF{
+    name: "Spending August 2016",
+    description: "This file contains the spending data for ...",
+    url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
+    format: "CSV",
+    dataset_id: dft_spending.id 
+})

--- a/src/dguweb/test/controllers/dataset_controller_test.exs
+++ b/src/dguweb/test/controllers/dataset_controller_test.exs
@@ -9,7 +9,7 @@ defmodule DGUWeb.DatasetControllerTest do
 
   test "lists all entries on index", %{conn: conn} do
     conn = get conn, dataset_path(conn, :index)
-    assert html_response(conn, 200) =~ "Listing datasets"
+    assert html_response(conn, 200) =~ "Datasets"
   end
 
   test "renders form for new resources", %{conn: conn} do
@@ -19,9 +19,9 @@ defmodule DGUWeb.DatasetControllerTest do
 
   test "creates resource and redirects when data is valid", %{conn: conn} do
     pub = Repo.insert! @publisher 
-    conn = post conn, dataset_path(conn, :create), dataset:   %{name: "some content", title: "some content", publisher_id: pub.id}
+    conn = post conn, dataset_path(conn, :create), dataset:   %{name: "test", title: "some content", publisher_id: pub.id}
     assert redirected_to(conn) == dataset_path(conn, :index)
-    assert Repo.get_by(Dataset, name: "some content")
+    assert Repo.get_by(Dataset, name: "test")
   end
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do
@@ -30,9 +30,9 @@ defmodule DGUWeb.DatasetControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    dataset = Repo.insert! %Dataset{}
-    conn = get conn, dataset_path(conn, :show, dataset)
-    assert html_response(conn, 200) =~ "Show dataset"
+    dataset = Repo.insert! %Dataset{name: "test", title: "Title"}
+    conn = get conn, dataset_path(conn, :show, dataset.name)
+    assert html_response(conn, 200) =~ "Title"
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do
@@ -42,28 +42,28 @@ defmodule DGUWeb.DatasetControllerTest do
   end
 
   test "renders form for editing chosen resource", %{conn: conn} do
-    dataset = Repo.insert! %Dataset{}
-    conn = get conn, dataset_path(conn, :edit, dataset)
+    dataset = Repo.insert! %Dataset{name: "test"}
+    conn = get conn, dataset_path(conn, :edit, dataset.name)
     assert html_response(conn, 200) =~ "Edit dataset"
   end
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
     pub = Repo.insert! @publisher 
-    dataset = Repo.insert! %Dataset{name: "some content", title: "some content", publisher_id: pub.id}
-    conn = put conn, dataset_path(conn, :update, dataset), dataset: %{name: "some content", title: "some content", publisher_id: pub.id}
-    assert redirected_to(conn) == dataset_path(conn, :show, dataset)
-    assert Repo.get_by(Dataset, name: "some content")
+    dataset = Repo.insert! %Dataset{name: "test", title: "some content", publisher_id: pub.id}
+    conn = put conn, dataset_path(conn, :update, dataset.name), dataset: %{name: "test", title: "some content", publisher_id: pub.id}
+    assert redirected_to(conn) == dataset_path(conn, :show, dataset.name)
+    assert Repo.get_by(Dataset, name: "test")
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    dataset = Repo.insert! %Dataset{}
-    conn = put conn, dataset_path(conn, :update, dataset), dataset: @invalid_attrs
+    dataset = Repo.insert! %Dataset{name: "test"}
+    conn = put conn, dataset_path(conn, :update, dataset.name), dataset: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit dataset"
   end
 
   test "deletes chosen resource", %{conn: conn} do
-    dataset = Repo.insert! %Dataset{}
-    conn = delete conn, dataset_path(conn, :delete, dataset)
+    dataset = Repo.insert! %Dataset{name: "test"}
+    conn = delete conn, dataset_path(conn, :delete, dataset.name)
     assert redirected_to(conn) == dataset_path(conn, :index)
     refute Repo.get(Dataset, dataset.id)
   end

--- a/src/dguweb/test/models/data_file_test.exs
+++ b/src/dguweb/test/models/data_file_test.exs
@@ -1,0 +1,18 @@
+defmodule DGUWeb.DataFileTest do
+  use DGUWeb.ModelCase
+
+  alias DGUWeb.DataFile
+
+  @valid_attrs %{description: "some content", format: "some content", name: "some content", url: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = DataFile.changeset(%DataFile{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = DataFile.changeset(%DataFile{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/src/dguweb/web/admin/datafile.ex
+++ b/src/dguweb/web/admin/datafile.ex
@@ -1,0 +1,7 @@
+defmodule DGUWeb.ExAdmin.DataFile do
+  use ExAdmin.Register
+
+  register_resource DGUWeb.DataFile do
+  end
+  
+end

--- a/src/dguweb/web/controllers/dataset_controller.ex
+++ b/src/dguweb/web/controllers/dataset_controller.ex
@@ -4,7 +4,7 @@ defmodule DGUWeb.DatasetController do
   alias DGUWeb.Dataset
 
   def index(conn, _params) do
-    datasets = Repo.all(Dataset)
+    datasets = Repo.all(Dataset) |> Repo.preload(:publisher)
     render(conn, "index.html", datasets: datasets)
   end
 
@@ -27,32 +27,35 @@ defmodule DGUWeb.DatasetController do
   end
 
   def show(conn, %{"id" => id}) do
-    dataset = Repo.get!(Dataset, id)
+    dataset = Repo.get_by!(Dataset, name: id) 
+    |> Repo.preload(:publisher)
+    |> Repo.preload(:datafiles)
+
     render(conn, "show.html", dataset: dataset)
   end
 
   def edit(conn, %{"id" => id}) do
-    dataset = Repo.get!(Dataset, id)
+    dataset = Repo.get_by!(Dataset, [name: id])
     changeset = Dataset.changeset(dataset)
     render(conn, "edit.html", dataset: dataset, changeset: changeset)
   end
 
   def update(conn, %{"id" => id, "dataset" => dataset_params}) do
-    dataset = Repo.get!(Dataset, id)
+    dataset = Repo.get_by!(Dataset, name: id)
     changeset = Dataset.changeset(dataset, dataset_params)
 
     case Repo.update(changeset) do
       {:ok, dataset} ->
         conn
         |> put_flash(:info, "Dataset updated successfully.")
-        |> redirect(to: dataset_path(conn, :show, dataset))
+        |> redirect(to: dataset_path(conn, :show, dataset.name))
       {:error, changeset} ->
         render(conn, "edit.html", dataset: dataset, changeset: changeset)
     end
   end
 
   def delete(conn, %{"id" => id}) do
-    dataset = Repo.get!(Dataset, id)
+    dataset = Repo.get_by!(Dataset, name: id)
 
     # Here we use delete! (with a bang) because we expect
     # it to always work (and if it does not, it will raise).

--- a/src/dguweb/web/controllers/publisher_controller.ex
+++ b/src/dguweb/web/controllers/publisher_controller.ex
@@ -29,6 +29,8 @@ defmodule DGUWeb.PublisherController do
 
   def show(conn, %{"id" => id}) do
     publisher = Repo.get_by!(Publisher, name: id)
+    |> Repo.preload(:datasets)
+
     render(conn, "show.html", publisher: publisher)
   end
 

--- a/src/dguweb/web/models/data_file.ex
+++ b/src/dguweb/web/models/data_file.ex
@@ -1,0 +1,22 @@
+defmodule DGUWeb.DataFile do
+  use DGUWeb.Web, :model
+
+  schema "datafiles" do
+    field :name, :string
+    field :description, :string
+    field :url, :string
+    field :format, :string
+    belongs_to :dataset, DGUWeb.Dataset
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:name, :description, :url, :format, :dataset_id])
+    |> validate_required([:name, :description, :url, :format])
+  end
+end

--- a/src/dguweb/web/models/dataset.ex
+++ b/src/dguweb/web/models/dataset.ex
@@ -5,7 +5,7 @@ defmodule DGUWeb.Dataset do
     field :name, :string
     field :title, :string
     belongs_to :publisher, DGUWeb.Publisher
-
+    has_many :datafiles, DGUWeb.DataFile
     timestamps()
   end
 

--- a/src/dguweb/web/templates/dataset/index.html.eex
+++ b/src/dguweb/web/templates/dataset/index.html.eex
@@ -1,28 +1,33 @@
-<h2>Listing datasets</h2>
+<h1 class="heading-xlarge">Datasets</h1>
 
-<table class="table">
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Title</th>
-
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-<%= for dataset <- @datasets do %>
-    <tr>
-      <td><%= dataset.name %></td>
-      <td><%= dataset.title %></td>
-
-      <td class="text-right">
-        <%= link "Show", to: dataset_path(@conn, :show, dataset), class: "btn btn-default btn-xs" %>
-        <%= link "Edit", to: dataset_path(@conn, :edit, dataset), class: "btn btn-default btn-xs" %>
-        <%= link "Delete", to: dataset_path(@conn, :delete, dataset), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
-      </td>
-    </tr>
-<% end %>
-  </tbody>
-</table>
-
-<%= link "New dataset", to: dataset_path(@conn, :new) %>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+    <%= for dataset <- @datasets do %>
+        <tr>
+          <td>
+            <%= dataset.title %> <br/>
+            <small><%= dataset.publisher.title %></small>
+            
+          </td>
+          <td>
+            <%= link "Show", to: dataset_path(@conn, :show, dataset.name), class: "btn btn-default btn-xs" %>
+            <%= link "Edit", to: dataset_path(@conn, :edit, dataset.name), class: "btn btn-default btn-xs" %>
+            <%= link "Delete", to: dataset_path(@conn, :delete, dataset.name), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+          </td>
+        </tr>
+    <% end %>
+      </tbody>
+    </table>
+  </div>
+  <div class="column-one-third">
+  &nbsp;
+  </div>
+</div>

--- a/src/dguweb/web/templates/dataset/show.html.eex
+++ b/src/dguweb/web/templates/dataset/show.html.eex
@@ -1,7 +1,13 @@
-<h2>Show dataset</h2>
+<h1 class="heading-xlarge">
+    <%= @dataset.title %>
+</h1>
+
+<%= if @dataset.publisher do  %>
+    <div>Published by: <a href="<%= publisher_path(@conn, :show, @dataset.publisher.name) %>"><%= @dataset.publisher.title %></a></div>
+<hr/> 
+<% end %>
 
 <ul>
-
   <li>
     <strong>Name:</strong>
     <%= @dataset.name %>
@@ -11,8 +17,38 @@
     <strong>Title:</strong>
     <%= @dataset.title %>
   </li>
-
 </ul>
 
-<%= link "Edit", to: dataset_path(@conn, :edit, @dataset) %>
-<%= link "Back", to: dataset_path(@conn, :index) %>
+<hr/>
+
+<div class="grid-row">
+
+<h1 class="heading-large">Files</h1>
+
+
+<%= for file <- @dataset.datafiles do %>
+<div class="column-one-half" style="border: solid 2px #eee; overflow-x: scroll;">
+        <table>
+            <tr>
+                <th>Name:</th>
+                <td><%= file.name %></td>
+            </tr>
+            <tr>
+                <th>Description:</th>
+                <td><%= file.description %></td>
+            </tr>            
+            <tr>
+                <th>URL:</th>
+                <td><%= file.url %></td>
+            </tr>      
+            <tr>
+                <th>Format:</th>
+                <td><%= file.format %></td>                
+            </tr>                  
+            
+        </table>
+</div>
+<% end %>
+
+
+</div>

--- a/src/dguweb/web/templates/publisher/show.html.eex
+++ b/src/dguweb/web/templates/publisher/show.html.eex
@@ -69,9 +69,30 @@
     <strong>Phone:</strong>
     <%= @publisher.contact_phone %>
   </li>
-
-
 </ul>
 
-<%= link "Edit", to: publisher_path(@conn, :edit, @publisher.name) %>
-<%= link "Back", to: publisher_path(@conn, :index) %>
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+    <%= for dataset <- @publisher.datasets do %>
+        <tr>
+          <td>
+            <a href="<%= dataset_path(@conn, :show, dataset.name) %>">
+            <%= dataset.title %> <br/>
+            </a>
+          </td>
+        </tr>
+    <% end %>
+      </tbody>
+    </table>
+  </div>
+  <div class="column-one-third">
+  &nbsp;
+  </div>
+</div>


### PR DESCRIPTION
publishers.

Each dataset currently has a fake `datafile` which contains
information about the file, such as the URL, name and hopefully
a description of the dataset.

There are also changes to the publisher index templates to show the
datasets for that publisher, updates on the dataset show page to include
the datafiles etc.

Fixes #14 
