### PR TITLE
Adds a description field to datasets.

### DIFF
--- a/src/dguweb/priv/repo/migrations/20160812123907_add_dataset_description.exs
+++ b/src/dguweb/priv/repo/migrations/20160812123907_add_dataset_description.exs
@@ -1,0 +1,9 @@
+defmodule DGUWeb.Repo.Migrations.AddDatasetDescription do
+  use Ecto.Migration
+
+  def change do
+    alter table(:datasets) do
+      add :description, :text
+    end
+  end
+end

--- a/src/dguweb/priv/repo/seeds.exs
+++ b/src/dguweb/priv/repo/seeds.exs
@@ -10,14 +10,17 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-alias DGUWeb.Repo, as: R 
+alias DGUWeb.Repo, as: R
 alias DGUWeb.Theme, as: T
-alias DGUWeb.Dataset, as: D 
-alias DGUWeb.DataFile, as: DF 
-alias DGUWeb.Publisher, as: P 
+alias DGUWeb.Dataset, as: D
+alias DGUWeb.DataFile, as: DF
+alias DGUWeb.Publisher, as: P
 alias DGUWeb.PublisherUser, as: PU
 
 # Themes ######################################################################
+
+R.clear_index
+R.create_index
 
 R.delete_all T
 
@@ -108,30 +111,30 @@ cabinet_office = R.insert!(%P{
     name: "cabinet-office",
     title: "Cabinet Office",
     description: "The Cabinet Office supports the Prime Minister and Deputy Prime Minister, and ensure the effective running of government. We are also the corporate headquarters for government, in partnership with HM Treasury, and we take the lead in certain critical policy areas. CO is a ministerial department, supported by 18 agencies and public bodies",
-    abbreviation: "CO",    
-    url: "https://www.gov.uk/government/organisations/cabinet-office",    
+    abbreviation: "CO",
+    url: "https://www.gov.uk/government/organisations/cabinet-office",
     category: "ministerial-department",
-    closed: false, 
+    closed: false,
 })
 
 defra = R.insert!(%P{
     name: "department-for-environment-food-rural-affairs",
     title: "Department for Environment, Food and Rural Affairs",
     description: "We are the UK government department responsible for policy and regulations on environmental, food and rural issues. Our priorities are to grow the rural economy, improve the environment and safeguard animal and plant health. Defra is a ministerial department, supported by 38 agencies and public bodies.",
-    abbreviation: "DEFRA",    
-    url: "https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs",    
+    abbreviation: "DEFRA",
+    url: "https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs",
     category: "ministerial-department",
-    closed: false, 
+    closed: false,
 })
 
 dft = R.insert!(%P{
     name: "department-for-transport",
     title: "Department for Transport",
     description: "We work with our agencies and partners to support the transport network that helps the UK’s businesses and gets people and goods travelling around the country. We plan and invest in transport infrastructure to keep the UK on the move. DFT is a ministerial department, supported by 22 agencies and public bodies.",
-    abbreviation: "DfT",    
-    url: "https://www.gov.uk/government/organisations/department-for-transport",    
+    abbreviation: "DfT",
+    url: "https://www.gov.uk/government/organisations/department-for-transport",
     category: "ministerial-department",
-    closed: false, 
+    closed: false,
 })
 
 # Datasets ######################################################################
@@ -139,7 +142,8 @@ dft = R.insert!(%P{
 co_organogram = R.insert!(%D{
     name: "co-organogram",
     title: "Organogram",
-    publisher_id: cabinet_office.id 
+    description: "The organogram for the Cabinet Office that explains the structure of the organisation",
+    publisher_id: cabinet_office.id
 })
 
 R.insert!(%DF{
@@ -147,13 +151,14 @@ R.insert!(%DF{
     description: "This file contains the spending data for ...",
     url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
     format: "CSV",
-    dataset_id: co_organogram.id 
+    dataset_id: co_organogram.id
 })
 
 defra_organogram = R.insert!(%D{
     name: "defra-organogram",
     title: "Organogram",
-    publisher_id: defra.id 
+    description: "The organogram for Defra that explains the structure of the organisation",
+    publisher_id: defra.id
 })
 
 R.insert!(%DF{
@@ -161,13 +166,14 @@ R.insert!(%DF{
     description: "This file contains the spending data for ...",
     url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
     format: "CSV",
-    dataset_id: defra_organogram.id 
+    dataset_id: defra_organogram.id
 })
 
 dft_organogram = R.insert!(%D{
     name: "dft-organogram",
     title: "Organogram",
-    publisher_id: dft.id 
+    description: "The organogram that explains the structure of the organisation",
+    publisher_id: dft.id
 })
 
 R.insert!(%DF{
@@ -175,13 +181,14 @@ R.insert!(%DF{
     description: "This file contains the spending data for ...",
     url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
     format: "CSV",
-    dataset_id: dft_organogram.id 
+    dataset_id: dft_organogram.id
 })
 
 co_spending = R.insert!(%D{
     name: "co-spending",
     title: "Spending",
-    publisher_id: cabinet_office.id 
+    description: "This is the Cabinet Office spending data which records all of the organisation's spending greater than £500.",
+    publisher_id: cabinet_office.id
 })
 
 R.insert!(%DF{
@@ -189,13 +196,14 @@ R.insert!(%DF{
     description: "This file contains the spending data for ...",
     url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
     format: "CSV",
-    dataset_id: co_spending.id 
+    dataset_id: co_spending.id
 })
 
 defra_spending = R.insert!(%D{
     name: "defra-spending",
     title: "Spending",
-    publisher_id: defra.id 
+    description: "This is the Defra spending data which records all of the organisation's spending greater than £500.",
+    publisher_id: defra.id
 })
 
 R.insert!(%DF{
@@ -203,13 +211,14 @@ R.insert!(%DF{
     description: "This file contains the spending data for ...",
     url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
     format: "CSV",
-    dataset_id: defra_spending.id 
+    dataset_id: defra_spending.id
 })
 
 dft_spending = R.insert!(%D{
     name: "dft-spending",
     title: "Spending",
-    publisher_id: dft.id 
+    description: "This is the Department for Transport spending data which records all of the organisation's spending greater than £500.",
+    publisher_id: dft.id
 })
 
 R.insert!(%DF{
@@ -217,5 +226,5 @@ R.insert!(%DF{
     description: "This file contains the spending data for ...",
     url: "http://dguproto1.northeurope.cloudapp.azure.com/fakecsv",
     format: "CSV",
-    dataset_id: dft_spending.id 
+    dataset_id: dft_spending.id
 })

--- a/src/dguweb/test/controllers/dataset_controller_test.exs
+++ b/src/dguweb/test/controllers/dataset_controller_test.exs
@@ -2,7 +2,7 @@ defmodule DGUWeb.DatasetControllerTest do
   use DGUWeb.ConnCase
 
   alias DGUWeb.Dataset
-  alias DGUWeb.Publisher 
+  alias DGUWeb.Publisher
 
   @publisher %Publisher{name: "some content", title: "some content", url: "some content"}
   @invalid_attrs %{}
@@ -18,8 +18,8 @@ defmodule DGUWeb.DatasetControllerTest do
   end
 
   test "creates resource and redirects when data is valid", %{conn: conn} do
-    pub = Repo.insert! @publisher 
-    conn = post conn, dataset_path(conn, :create), dataset:   %{name: "test", title: "some content", publisher_id: pub.id}
+    pub = Repo.insert! @publisher
+    conn = post conn, dataset_path(conn, :create), dataset:   %{name: "test", title: "some content", description: "Description", publisher_id: pub.id}
     assert redirected_to(conn) == dataset_path(conn, :index)
     assert Repo.get_by(Dataset, name: "test")
   end
@@ -30,7 +30,7 @@ defmodule DGUWeb.DatasetControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    dataset = Repo.insert! %Dataset{name: "test", title: "Title"}
+    dataset = Repo.insert! %Dataset{name: "test", title: "Title", description: "Description",}
     conn = get conn, dataset_path(conn, :show, dataset.name)
     assert html_response(conn, 200) =~ "Title"
   end
@@ -48,9 +48,11 @@ defmodule DGUWeb.DatasetControllerTest do
   end
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    pub = Repo.insert! @publisher 
+    pub = Repo.insert! @publisher
     dataset = Repo.insert! %Dataset{name: "test", title: "some content", publisher_id: pub.id}
-    conn = put conn, dataset_path(conn, :update, dataset.name), dataset: %{name: "test", title: "some content", publisher_id: pub.id}
+    conn = put conn, dataset_path(conn, :update, dataset.name), dataset: %{
+      name: "test", title: "some content", description: "Description", publisher_id: pub.id
+    }
     assert redirected_to(conn) == dataset_path(conn, :show, dataset.name)
     assert Repo.get_by(Dataset, name: "test")
   end

--- a/src/dguweb/test/models/dataset_test.exs
+++ b/src/dguweb/test/models/dataset_test.exs
@@ -8,8 +8,10 @@ defmodule DGUWeb.DatasetTest do
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do
-    pub = Repo.insert! %Publisher{name: "some content", title: "some content", url: "some content"}
-    changeset = Dataset.changeset(%Dataset{}, %{name: "some content", title: "some content", publisher_id: pub.id})
+    pub = Repo.insert! %Publisher{name: "some content", title: "some content",description: "Description", url: "some content"}
+    changeset = Dataset.changeset(%Dataset{}, %{
+      name: "some content", title: "some content", description: "Description", publisher_id: pub.id
+    })
     assert changeset.valid?
   end
 

--- a/src/dguweb/web/models/dataset.ex
+++ b/src/dguweb/web/models/dataset.ex
@@ -6,40 +6,41 @@ defmodule DGUWeb.Dataset do
   schema "datasets" do
     field :name, :string
     field :title, :string
+    field :description, :string
     belongs_to :publisher, DGUWeb.Publisher
     has_many :datafiles, DGUWeb.DataFile
     timestamps()
   end
 
-  @required_fields [:name, :title, :publisher_id]
+  @required_fields [:name, :title, :publisher_id, :description]
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:name, :title, :publisher_id])
+    |> cast(params, [:name, :title, :description, :publisher_id])
     |> validate_required(@required_fields)
   end
 
-  def fields_for_search(dataset) do 
-      d = dataset 
-      |> Repo.preload(:publisher) 
+  def fields_for_search(dataset) do
+      d = dataset
+      |> Repo.preload(:publisher)
 
     fields_with_publisher( d, d.publisher )
-  end 
+  end
 
-  def fields_with_publisher(dataset, nil) do 
+  def fields_with_publisher(dataset, nil) do
     dataset
     |> Map.take([:name, :title, :description])
     |> Enum.into([])
-  end 
+  end
 
-  def fields_with_publisher(dataset, publisher) do     
+  def fields_with_publisher(dataset, publisher) do
     dataset
     |> Map.take([:name, :title, :description])
     |> Map.put(:publisher_name, publisher.name)
-    |> Map.put(:publisher_title, publisher.title)    
+    |> Map.put(:publisher_title, publisher.title)
     |> Enum.into([])
   end
 

--- a/src/dguweb/web/templates/dataset/show.html.eex
+++ b/src/dguweb/web/templates/dataset/show.html.eex
@@ -4,7 +4,7 @@
 
 <%= if @dataset.publisher do  %>
     <div>Published by: <a href="<%= publisher_path(@conn, :show, @dataset.publisher.name) %>"><%= @dataset.publisher.title %></a></div>
-<hr/> 
+<hr/>
 <% end %>
 
 <ul>
@@ -17,6 +17,13 @@
     <strong>Title:</strong>
     <%= @dataset.title %>
   </li>
+
+
+  <li>
+    <strong>Description:</strong>
+    <%= @dataset.description %>
+  </li>
+
 </ul>
 
 <hr/>
@@ -36,16 +43,16 @@
             <tr>
                 <th>Description:</th>
                 <td><%= file.description %></td>
-            </tr>            
+            </tr>
             <tr>
                 <th>URL:</th>
                 <td><%= file.url %></td>
-            </tr>      
+            </tr>
             <tr>
                 <th>Format:</th>
-                <td><%= file.format %></td>                
-            </tr>                  
-            
+                <td><%= file.format %></td>
+            </tr>
+
         </table>
 </div>
 <% end %>

--- a/src/dguweb/web/templates/search/dataset_item.html.eex
+++ b/src/dguweb/web/templates/search/dataset_item.html.eex
@@ -2,8 +2,10 @@
 <div style="padding: 12px;">
 <a href="<%= dataset_path(@conn, :show, @dataset.name) %>"><%= @dataset.title %></a><br/>
 <%= if Map.get(@dataset, :publisher_name) do %>
-Published by: 
+Published by:
 <a href="<%= publisher_path(@conn, :show, @dataset.publisher_name) %>"><%= @dataset.publisher_title %></a>
+<br/>
+<%= @dataset.description %>
 <% end %>
 
 </div>


### PR DESCRIPTION
- Adds a description field
- Makes it searchable
- Displays on /dataset/NAME and search results
- Drive by cleanup to:
  - Cleanup output from indexer
  - Clear the search index before seeding the database.
  - Use the snowball stemmer in the created index.
