### PR TITLE
Fix parameter that will be passed as part of URL

### DIFF
--- a/src/dguweb/web/templates/publisher/edit.html.eex
+++ b/src/dguweb/web/templates/publisher/edit.html.eex
@@ -1,6 +1,6 @@
 <h1 class="heading-xlarge">Edit <%= @publisher.title %></h1>
 
 <%= render "form.html", changeset: @changeset,
-                        action: publisher_path(@conn, :update, @publisher) %>
+                        action: publisher_path(@conn, :update, @publisher.name) %>
 
 <%= link "Back", to: publisher_path(@conn, :index) %>


### PR DESCRIPTION
By default, if you pass @publisher it will use the PK (the id field),
but we switched to using the name field so we can access them as slugs.
Whenever you use publisher_path you should pass @publisher.name instead
of @publisher.

Fixes #32 
