### PR TITLE
Autocomplete endpoint

### DIFF
--- a/src/dguweb/test/controllers/search_controller_test.exs
+++ b/src/dguweb/test/controllers/search_controller_test.exs
@@ -1,0 +1,17 @@
+defmodule DGUWeb.SearchControllerTest do
+  use DGUWeb.ConnCase
+
+  @valid_attrs %{}
+  @invalid_attrs %{}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "lists all entries on query when empty", %{conn: conn} do
+    conn = get conn, search_path(conn, :search, q: "")
+    assert json_response(conn, 200) == []
+  end
+
+
+end

--- a/src/dguweb/web/controllers/search_controller.ex
+++ b/src/dguweb/web/controllers/search_controller.ex
@@ -1,19 +1,18 @@
 defmodule DGUWeb.SearchController do
   use DGUWeb.Web, :controller
-  
+
   alias Tirexs.HTTP, as: Search
 
   def index(conn, _params) do
-    render conn, "index.html" 
+    render conn, :index
   end
 
-  def search(conn, params) do
-    query = params |> Map.get("q")
-
+  def search(conn, %{"q" => query}) do
     q = query |> String.replace(" ","+")
     result = Repo.search(q)
-
-    render conn, "search.html", query: query, results: result.hits.hits, total: result.hits.total
+    render conn, :search, query: query, results: result.hits.hits, total: result.hits.total
   end
+
+  def search(conn, %{}), do: render conn, :search, query: "", results: [], total: 0
 
 end

--- a/src/dguweb/web/router.ex
+++ b/src/dguweb/web/router.ex
@@ -8,7 +8,7 @@ defmodule DGUWeb.Router do
   end
 
   pipeline :browser do
-    plug :accepts, ["html"]
+    plug :accepts, ["html", "json"]
     plug :fetch_session
     plug :fetch_flash
     #plug :protect_from_forgery
@@ -21,7 +21,7 @@ defmodule DGUWeb.Router do
     get "/", PageController, :index
 
     get "/search", SearchController, :search
-    
+
     get "/publish", PublishController, :index
     post "/publish", PublishController, :add_file
     get "/publish/find", PublishController, :find
@@ -39,13 +39,4 @@ defmodule DGUWeb.Router do
     get "/fakecsv", DatasetController, :fakecsv
   end
 
-
-  pipeline :api do
-    plug :accepts, ["json"]
-  end
-
-  # Other scopes may use custom stacks.
-  # scope "/api", DGUWeb do
-  #   pipe_through :api
-  # end
 end

--- a/src/dguweb/web/templates/search/search.html.eex
+++ b/src/dguweb/web/templates/search/search.html.eex
@@ -27,7 +27,9 @@
             <% end %>
     <% end %>
 <% else %>
+    <%= if @query != "" do %>
     <p>Search returned 0 results</p>
+    <% end %>
 <% end %>
 </div>
 

--- a/src/dguweb/web/views/changeset_view.ex
+++ b/src/dguweb/web/views/changeset_view.ex
@@ -1,0 +1,19 @@
+defmodule DGUWeb.ChangesetView do
+  use DGUWeb.Web, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+
+  See `Ecto.Changeset.traverse_errors/2` and
+  `DGUWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/src/dguweb/web/views/search_view.ex
+++ b/src/dguweb/web/views/search_view.ex
@@ -1,3 +1,10 @@
 defmodule DGUWeb.SearchView do
   use DGUWeb.Web, :view
+
+  def render("search.json", %{results: datasets}) do
+    datasets
+    |> Enum.map( fn x-> x._source end)
+  end
+
+
 end


### PR DESCRIPTION
The endpoint is at /search and although this will generally serve HTML,
if you set the correct headers it will return the JSON version.  You can
mimic this with /search?q=terms&_format=json
