### PR TITLE
Add a type field to datasets

### DIFF
--- a/src/dguweb/priv/repo/migrations/20160814155416_add dataset types.exs
+++ b/src/dguweb/priv/repo/migrations/20160814155416_add dataset types.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.DGUWeb.Repo.Migrations.Add dataset types" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:datasets) do
+      add :type, :string
+    end
+  end
+end

--- a/src/dguweb/priv/repo/seeds.exs
+++ b/src/dguweb/priv/repo/seeds.exs
@@ -143,7 +143,8 @@ co_organogram = R.insert!(%D{
     name: "co-organogram",
     title: "Organogram",
     description: "The organogram for the Cabinet Office that explains the structure of the organisation",
-    publisher_id: cabinet_office.id
+    publisher_id: cabinet_office.id,
+    type: "organogram"
 })
 
 R.insert!(%DF{
@@ -158,7 +159,8 @@ defra_organogram = R.insert!(%D{
     name: "defra-organogram",
     title: "Organogram",
     description: "The organogram for Defra that explains the structure of the organisation",
-    publisher_id: defra.id
+    publisher_id: defra.id,
+    type: "organogram"
 })
 
 R.insert!(%DF{
@@ -173,7 +175,8 @@ dft_organogram = R.insert!(%D{
     name: "dft-organogram",
     title: "Organogram",
     description: "The organogram that explains the structure of the organisation",
-    publisher_id: dft.id
+    publisher_id: dft.id,
+    type: "organogram"
 })
 
 R.insert!(%DF{
@@ -188,7 +191,8 @@ co_spending = R.insert!(%D{
     name: "co-spending",
     title: "Spending",
     description: "This is the Cabinet Office spending data which records all of the organisation's spending greater than £500.",
-    publisher_id: cabinet_office.id
+    publisher_id: cabinet_office.id,
+    type: "spending"
 })
 
 R.insert!(%DF{
@@ -203,7 +207,8 @@ defra_spending = R.insert!(%D{
     name: "defra-spending",
     title: "Spending",
     description: "This is the Defra spending data which records all of the organisation's spending greater than £500.",
-    publisher_id: defra.id
+    publisher_id: defra.id,
+    type: "spending"
 })
 
 R.insert!(%DF{
@@ -218,7 +223,8 @@ dft_spending = R.insert!(%D{
     name: "dft-spending",
     title: "Spending",
     description: "This is the Department for Transport spending data which records all of the organisation's spending greater than £500.",
-    publisher_id: dft.id
+    publisher_id: dft.id,
+    type: "spending"
 })
 
 R.insert!(%DF{

--- a/src/dguweb/web/models/dataset.ex
+++ b/src/dguweb/web/models/dataset.ex
@@ -7,6 +7,8 @@ defmodule DGUWeb.Dataset do
     field :name, :string
     field :title, :string
     field :description, :string
+    field :type, :string
+
     belongs_to :publisher, DGUWeb.Publisher
     has_many :datafiles, DGUWeb.DataFile
     timestamps()
@@ -19,7 +21,7 @@ defmodule DGUWeb.Dataset do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:name, :title, :description, :publisher_id])
+    |> cast(params, [:name, :title, :description, :type, :publisher_id])
     |> validate_required(@required_fields)
   end
 
@@ -32,13 +34,13 @@ defmodule DGUWeb.Dataset do
 
   def fields_with_publisher(dataset, nil) do
     dataset
-    |> Map.take([:name, :title, :description])
+    |> Map.take([:name, :title, :description, :type])
     |> Enum.into([])
   end
 
   def fields_with_publisher(dataset, publisher) do
     dataset
-    |> Map.take([:name, :title, :description])
+    |> Map.take([:name, :title, :description, :type])
     |> Map.put(:publisher_name, publisher.name)
     |> Map.put(:publisher_title, publisher.title)
     |> Enum.into([])

--- a/src/dguweb/web/templates/session/login.html.eex
+++ b/src/dguweb/web/templates/session/login.html.eex
@@ -1,6 +1,6 @@
 <h1 class="heading-xlarge">Sign in</h1>
 
-<%= form_for @conn, session_path(@conn, :login), [name: :session], fn f -> %>
+<%= form_for @conn, session_path(@conn, :login), [as: :session], fn f -> %>
 
   <div class="form-group">
     <label>Username</label>


### PR DESCRIPTION
Adds a field to datasets so that we can specify its type.  For instance, we want a type of 'organogram' that way, for a given publisher we can easily find their organogram dataset.
