### PR TITLE
Some changes to the publisher index+show pages

### DIFF
--- a/src/dguweb/web/controllers/publish_controller.ex
+++ b/src/dguweb/web/controllers/publish_controller.ex
@@ -6,14 +6,13 @@ defmodule DGUWeb.PublishController do
 
   def index(conn, _params) do
     conn
-    |> clear_session
     |> render("index.html", current_files: [], error: :nil)
   end
 
   ### Add File, upload or URL ################################################
   #
-  # When (if) we decide that this is better tracked in the database, we can 
-  # rely on the changeset to handle the difference validation requirements 
+  # When (if) we decide that this is better tracked in the database, we can
+  # rely on the changeset to handle the difference validation requirements
   # and/or we can change the process flow.
   #
   ############################################################################
@@ -23,32 +22,32 @@ defmodule DGUWeb.PublishController do
     url = Map.get(params, "url", :nil)
 
     add_file_internal(conn, {file, url})
-  end 
+  end
 
   defp add_file_internal(conn, {:nil, :nil}), do: failed_add_file(conn, "Please supply a URL or a file upload.")
-  defp add_file_internal(conn, {upload, ""}) do 
+  defp add_file_internal(conn, {upload, ""}) do
     info = UploadInfo.from_upload(upload)
     spawn(fn-> Tasks.run_tasks(info, Tasks.file_tasks) end )
     progress_add_file(conn, info)
-  end 
+  end
 
-  defp add_file_internal(conn, {:nil, "http" <> url}) do 
+  defp add_file_internal(conn, {:nil, "http" <> url}) do
     info = UploadInfo.from_url("http" <> url)
     |>  Tasks.run_tasks(Tasks.url_tasks)
 
-    case info.errors do 
+    case info.errors do
       [] -> progress_add_file(conn, info)
       [x] -> failed_add_file(conn, x)
-    end 
-    
-  end 
+    end
+
+  end
 
   defp add_file_internal(conn, {:nil, _url}), do: failed_add_file(conn, "URL does not appear to be valid")
   defp add_file_internal(conn, {_, _}), do: failed_add_file(conn, "Please supply a URL or a file upload, not both")
 
-  defp failed_add_file(conn, error) do 
+  defp failed_add_file(conn, error) do
     conn
-    |> render("index.html", current_files: [], error: error)    
+    |> render("index.html", current_files: [], error: error)
   end
 
   defp progress_add_file(conn, info) do
@@ -57,15 +56,15 @@ defmodule DGUWeb.PublishController do
     conn
     |> put_session(:current_files, current)
     |> redirect(to: publish_path(conn, :find, []))
-  end 
+  end
 
   ### Determine what the user wants to do with the uploaded data #############
 
-  def find(conn, _params) do 
+  def find(conn, _params) do
     current = get_session(conn, :current_files) || []
 
     render(conn, "find.html", current_files: current)
-  end 
+  end
 
 
 end

--- a/src/dguweb/web/controllers/session_controller.ex
+++ b/src/dguweb/web/controllers/session_controller.ex
@@ -31,6 +31,7 @@ defmodule DGUWeb.SessionController do
       {:ok, user} ->
         conn
         |> put_session(:current_user, user.id)
+        |> put_session(:current_user_publishers, User.publishers(user))
         |> put_flash(:info, "Logged in")
         |> redirect(to: "/user")
       :error ->

--- a/src/dguweb/web/controllers/user_controller.ex
+++ b/src/dguweb/web/controllers/user_controller.ex
@@ -1,13 +1,13 @@
 defmodule DGUWeb.UserController do
   use DGUWeb.Web, :controller
-  
+
   def index(conn, _params) do
-    user = conn |> DGUWeb.Session.current_user     
+    user = conn |> DGUWeb.Session.current_user
     do_index(conn, user)
-  end 
+  end
 
   defp do_index(conn, nil), do: redirect(conn, to: "/")
-  defp do_index(conn, user) do 
+  defp do_index(conn, user) do
     userpubs = DGUWeb.User.publishers(user)
     render(conn, "index.html", publishers: userpubs)
   end

--- a/src/dguweb/web/templates/publisher/index.html.eex
+++ b/src/dguweb/web/templates/publisher/index.html.eex
@@ -3,30 +3,23 @@
 <table class="table">
   <thead>
     <tr>
-      <th>Name</th>
       <th>Title</th>
-      <%= if logged_in?(@conn) do %>
-        <th>Actions</th>
-      <% end %>
+        <th></th>
     </tr>
   </thead>
   <tbody>
     <%= for publisher <- @publishers do %>
       <tr>
-        <td><%= publisher.name %></td>
-        <td><a href="<%= publisher.url %>"><%= publisher.title %></a></td>
-        <%= if logged_in?(@conn) do %>
-          <td class="text-right">
-            <%= link "Show", to: publisher_path(@conn, :show, publisher.name), class: "btn btn-default btn-xs" %>
-            <%= link "Edit", to: publisher_path(@conn, :edit, publisher.name), class: "btn btn-default btn-xs" %>
-            <%= link "Delete", to: publisher_path(@conn, :delete, publisher.name), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+        <td>
+          <a href="<%= publisher_path(@conn, :show, publisher.name) %>"><%= publisher.title %></a>
           </td>
-        <% end %>
+          <td class="text-right">
+          <%= if user_in_publisher(@conn, publisher.name) do %>
+              <%= link "Edit", to: publisher_path(@conn, :edit, publisher.name), class: "btn btn-default btn-xs" %>
+            <% end %>
+          </td>
       </tr>
     <% end %>
   </tbody>
 </table>
 
-<%= if logged_in?(@conn) do %>
-  <%= link "Add a publisher", to: publisher_path(@conn, :new) %>
-<% end %>

--- a/src/dguweb/web/templates/publisher/show.html.eex
+++ b/src/dguweb/web/templates/publisher/show.html.eex
@@ -1,78 +1,22 @@
 <h1 class="heading-xlarge"><%= @publisher.title %></h1>
 
-<ul>
+<div class="grid-row">
+  <div class="column-two-thirds">
+      <%= @publisher.description %>
+      <a target="_blank" href="<%= @publisher.url %>">More info</a>
+  </div>
 
-  <li>
-    <strong>Name:</strong>
-    <%= @publisher.name %>
-  </li>
-
-  <li>
-    <strong>Title:</strong>
-    <%= @publisher.title %>
-  </li>
-
-  <li>
-    <strong>Abbreviation:</strong>
-    <%= @publisher.abbreviation %>
-  </li>
-
-
-  <li>
-    <strong>Description:</strong>
-    <%= @publisher.description %>
-  </li>
-
-
-  <li>
-    <strong>Url:</strong>
-    <%= @publisher.url %>
-  </li>
-
-
-  <li>
-    <strong>Category:</strong>
-    <%= @publisher.category %>
-  </li>
-
-<li>
-    <strong>Is Closed:</strong>
-    <%= @publisher.closed %>
-  </li>
-
-  <li>
-    <strong>FOI Name:</strong>
-    <%= @publisher.foi_name %>
-  </li>
-  <li>
-    <strong>FOI Email:</strong>
-    <%= @publisher.foi_email %>
-  </li>
-  <li>
-    <strong>FOI Phone:</strong>
-    <%= @publisher.foi_phone %>
-  </li>
-  <li>
-    <strong>FOI Web:</strong>
-    <%= @publisher.foi_web %>
-  </li>
-
-  <li>
-    <strong>Contact name:</strong>
-    <%= @publisher.contact_name %>
-  </li>
-  <li>
-    <strong>Contact email:</strong>
-    <%= @publisher.contact_email %>
-  </li>
-    <li>
-    <strong>Phone:</strong>
-    <%= @publisher.contact_phone %>
-  </li>
-</ul>
+    <div class="column-one-third">
+       <%= if user_in_publisher(@conn, @publisher.name) do %>
+            <a class="button" href="/publish?publisher=<%= @publisher.name %>">Add Data</a>
+            <br/> <br/>
+        <% end %>
+    </div>
+</div>
 
 <div class="grid-row">
   <div class="column-two-thirds">
+    <h1 class="heading-large">Datasets</h1>
     <table>
       <thead>
         <tr>
@@ -86,6 +30,10 @@
             <a href="<%= dataset_path(@conn, :show, dataset.name) %>">
             <%= dataset.title %> <br/>
             </a>
+            <%= dataset.description %>
+            <%= if user_in_publisher(@conn, @publisher.name) do %>
+              <a href="/publish?dataset=<%= dataset.name %>">Add data</a>
+            <% end %>
           </td>
         </tr>
     <% end %>
@@ -93,6 +41,6 @@
     </table>
   </div>
   <div class="column-one-third">
-  &nbsp;
+      &nbsp;
   </div>
 </div>

--- a/src/dguweb/web/views/publisher_view.ex
+++ b/src/dguweb/web/views/publisher_view.ex
@@ -1,3 +1,24 @@
 defmodule DGUWeb.PublisherView do
   use DGUWeb.Web, :view
+
+  alias DGUWeb.Session
+  alias DGUWeb.User
+
+  # FIXME(rdj): Replace when Authz in place.
+  def user_in_publisher(conn, publisher) do
+    publishers = conn
+    |> Session.current_user()
+    |>  publishers_for_user
+    |> Enum.filter( fn {pub, role} ->
+      pub.name == publisher
+    end)
+
+    length(publishers) > 0
+  end
+
+  def publishers_for_user(nil), do: []
+  def publishers_for_user(user) do
+    User.publishers(user)
+  end
+
 end


### PR DESCRIPTION
Remove some stuff from the publisher pages and add temporary auth so we
can model the user being able to add data (or not) to a particular
publisher.

Makes assumptions that the publisher workflow can take either a
publisher or a dataset (in which case the workflow is really short).

Hope you don't mind me removing stuff, I'm just trying to streamline the workflow a bit ...

Fixes #37 
