### PR TITLE
Move authn info into connection assignments

### DIFF
--- a/src/dguweb/web/controllers/publish_controller.ex
+++ b/src/dguweb/web/controllers/publish_controller.ex
@@ -12,8 +12,8 @@ defmodule DGUWeb.PublishController do
 
   ### Add File, upload or URL ################################################
   #
-  # When (if) we decide that this is better tracked in the database, we can 
-  # rely on the changeset to handle the difference validation requirements 
+  # When (if) we decide that this is better tracked in the database, we can
+  # rely on the changeset to handle the difference validation requirements
   # and/or we can change the process flow.
   #
   ############################################################################
@@ -23,32 +23,32 @@ defmodule DGUWeb.PublishController do
     url = Map.get(params, "url", :nil)
 
     add_file_internal(conn, {file, url})
-  end 
+  end
 
   defp add_file_internal(conn, {:nil, :nil}), do: failed_add_file(conn, "Please supply a URL or a file upload.")
-  defp add_file_internal(conn, {upload, ""}) do 
+  defp add_file_internal(conn, {upload, ""}) do
     info = UploadInfo.from_upload(upload)
     spawn(fn-> Tasks.run_tasks(info, Tasks.file_tasks) end )
     progress_add_file(conn, info)
-  end 
+  end
 
-  defp add_file_internal(conn, {:nil, "http" <> url}) do 
+  defp add_file_internal(conn, {:nil, "http" <> url}) do
     info = UploadInfo.from_url("http" <> url)
     |>  Tasks.run_tasks(Tasks.url_tasks)
 
-    case info.errors do 
+    case info.errors do
       [] -> progress_add_file(conn, info)
       [x] -> failed_add_file(conn, x)
-    end 
-    
-  end 
+    end
+
+  end
 
   defp add_file_internal(conn, {:nil, _url}), do: failed_add_file(conn, "URL does not appear to be valid")
   defp add_file_internal(conn, {_, _}), do: failed_add_file(conn, "Please supply a URL or a file upload, not both")
 
-  defp failed_add_file(conn, error) do 
+  defp failed_add_file(conn, error) do
     conn
-    |> render("index.html", current_files: [], error: error)    
+    |> render("index.html", current_files: [], error: error)
   end
 
   defp progress_add_file(conn, info) do
@@ -57,15 +57,15 @@ defmodule DGUWeb.PublishController do
     conn
     |> put_session(:current_files, current)
     |> redirect(to: publish_path(conn, :find, []))
-  end 
+  end
 
   ### Determine what the user wants to do with the uploaded data #############
 
-  def find(conn, _params) do 
+  def find(conn, _params) do
     current = get_session(conn, :current_files) || []
 
     render(conn, "find.html", current_files: current)
-  end 
+  end
 
 
 end

--- a/src/dguweb/web/controllers/user_controller.ex
+++ b/src/dguweb/web/controllers/user_controller.ex
@@ -1,15 +1,15 @@
 defmodule DGUWeb.UserController do
   use DGUWeb.Web, :controller
-  
+
   def index(conn, _params) do
-    user = conn |> DGUWeb.Session.current_user     
+    user = conn.assigns[:current_user]
     do_index(conn, user)
-  end 
+  end
 
   defp do_index(conn, nil), do: redirect(conn, to: "/")
-  defp do_index(conn, user) do 
-    userpubs = DGUWeb.User.publishers(user)
-    render(conn, "index.html", publishers: userpubs)
+  defp do_index(conn, user) do
+    publishers = conn.assigns[:user_publishers] || []
+    render(conn, "index.html", publishers: publishers)
   end
 
 end

--- a/src/dguweb/web/models/session.ex
+++ b/src/dguweb/web/models/session.ex
@@ -16,11 +16,6 @@ defmodule DGUWeb.Session do
     end
   end
 
-  def current_user(conn) do
-    id = Plug.Conn.get_session(conn, :current_user)
-    if id, do: DGUWeb.Repo.get(User, id)
-  end
-
-  def logged_in?(conn), do: !!current_user(conn)
+  def logged_in?(conn), do: !!conn.assigns[:current_user]
 
 end

--- a/src/dguweb/web/models/user.ex
+++ b/src/dguweb/web/models/user.ex
@@ -16,26 +16,26 @@ defmodule DGUWeb.User do
   end
 
   @doc """
-  Retrieves the publishers that the given user is a member of. Because we want the role 
-  field in the join table however, we need to also map them separately to the memberships 
-  so we query the join table as well.  One day I hope this is fixed to allow the fields in 
+  Retrieves the publishers that the given user is a member of. Because we want the role
+  field in the join table however, we need to also map them separately to the memberships
+  so we query the join table as well.  One day I hope this is fixed to allow the fields in
   the join table to be retrieved as part of the same call.
   """
-  def publishers(user) do 
+  def publishers(user) do
       publishers = Repo.all assoc(user, :publisher)
       memberships = Repo.all(from(p in PublisherUser, where: p.user_id == ^user.id))
 
-      member_map = memberships 
-      |> Enum.map(fn x ->   
+      member_map = memberships
+      |> Enum.map(fn x ->
           {x.publisher_id, x.role}
       end)
       |> Enum.into(%{})
 
       publishers
-      |> Enum.map( fn p -> 
-        {p, Map.get(member_map, p.id)}
+      |> Enum.map( fn p ->
+        {p.name, %{role: Map.get(member_map, p.id), title: p.title}}
       end)
-  end 
+  end
 
   @doc """
   Builds a changeset based on the `struct` and `params`.
@@ -43,8 +43,8 @@ defmodule DGUWeb.User do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:username, :email, :password, :crypted_password])
-    |> validate_required([:username, :email, :password])    
-    |> validate_format(:email, ~r/@/)    
+    |> validate_required([:username, :email, :password])
+    |> validate_format(:email, ~r/@/)
     |> validate_length(:password, min: 5)
     |> unique_constraint(:username)
   end

--- a/src/dguweb/web/plugs/authentication.ex
+++ b/src/dguweb/web/plugs/authentication.ex
@@ -1,0 +1,24 @@
+defmodule DGUWeb.Plugs.Authentication do
+  import Plug.Conn
+  import Phoenix.Controller
+
+  alias DGUWeb.Repo
+  alias DGUWeb.User
+
+  def init(default), do: default
+
+  def call(conn, default) do
+    current_user = get_session(conn, :current_user)
+    if current_user do
+      user = Repo.get!(User, current_user)
+      publishers = user |> User.publishers
+
+      conn
+      |> assign(:current_user, user)
+      |> assign(:user_publishers, publishers)
+    else
+      conn
+    end
+
+  end
+end

--- a/src/dguweb/web/router.ex
+++ b/src/dguweb/web/router.ex
@@ -2,6 +2,8 @@ defmodule DGUWeb.Router do
   use DGUWeb.Web, :router
   use ExAdmin.Router
 
+  alias DGUWeb.Plugs.Authentication
+
   scope "/admin", ExAdmin do
     pipe_through :browser
     admin_routes
@@ -13,6 +15,7 @@ defmodule DGUWeb.Router do
     plug :fetch_flash
     #plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug Authentication
   end
 
   scope "/", DGUWeb do
@@ -21,7 +24,7 @@ defmodule DGUWeb.Router do
     get "/", PageController, :index
 
     get "/search", SearchController, :search
-    
+
     get "/publish", PublishController, :index
     post "/publish", PublishController, :add_file
     get "/publish/find", PublishController, :find

--- a/src/dguweb/web/templates/layout/app.html.eex
+++ b/src/dguweb/web/templates/layout/app.html.eex
@@ -90,7 +90,7 @@
   </nav>
   <%= if logged_in?(@conn) do %>
     <ul class="login-info">
-      <li>Logged in as <%= current_user(@conn).username %></li>
+      <li>Logged in as <%= @conn.assigns[:current_user].username %></li>
       <li><%= link "Sign out", to: session_path(@conn, :logout) %></li>
     </ul>
   <% end %>

--- a/src/dguweb/web/templates/user/index.html.eex
+++ b/src/dguweb/web/templates/user/index.html.eex
@@ -6,10 +6,10 @@
 <% end %>
 
 <ul>
-<%= for {name, m} <- @publishers do %>
+<%= for {pubname, pubmap} <- @publishers do %>
     <li>
-    <%= link m.title, to: publisher_path(@conn, :show, name) %>
-    (<%= m.role %>)
+    <%= link pubmap.title, to: publisher_path(@conn, :show, pubname) %>
+    (<%= pubmap.role %>)
     </li>
 <% end %>
 </ul>

--- a/src/dguweb/web/templates/user/index.html.eex
+++ b/src/dguweb/web/templates/user/index.html.eex
@@ -6,10 +6,10 @@
 <% end %>
 
 <ul>
-<%= for {pub, role} <- @publishers do %>
+<%= for {name, m} <- @publishers do %>
     <li>
-    <%= link pub.title, to: publisher_path(@conn, :show, pub.name) %>
-    (<%= role %>)
+    <%= link m.title, to: publisher_path(@conn, :show, name) %>
+    (<%= m.role %>)
     </li>
 <% end %>
 </ul>

--- a/src/dguweb/web/web.ex
+++ b/src/dguweb/web/web.ex
@@ -52,7 +52,7 @@ defmodule DGUWeb.Web do
       import DGUWeb.Router.Helpers
       import DGUWeb.ErrorHelpers
       import DGUWeb.Gettext
-      import DGUWeb.Session, only: [current_user: 1, logged_in?: 1]
+      import DGUWeb.Session, only: [logged_in?: 1]
     end
   end
 


### PR DESCRIPTION
To minimize calls to get the current user (from the DB) and the list of
publishers that the user belongs to, this PR assigns data to the connection ..

The user object to conn, access with @conn.assigns[:current_user]

The publishers that the user belongs to under
@conn.assigns[:user_publishers] which returns a list of

  { publisher_name, %{role: "admin", title: "publisher title"} }
