### PR TITLE
Adds a /download route for development

### DIFF
--- a/src/dguweb/config/config.exs
+++ b/src/dguweb/config/config.exs
@@ -33,6 +33,10 @@ config :ex_admin,
     DGUWeb.ExAdmin.DataFile,
   ]
 
+# Where are we storing downloads
+config :dguweb, upload_path: "/tmp", host: "http://127.0.0.1:4000"
+
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/src/dguweb/config/prod.exs
+++ b/src/dguweb/config/prod.exs
@@ -13,7 +13,7 @@ use Mix.Config
 # which you typically run after static files are built.
 config :dguweb, DGUWeb.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: [host: "example.com", port: 80],
+  url: [host: "dguproto1.northeurope.cloudapp.azure.com", port: 80],
   cache_static_manifest: "priv/static/manifest.json"
 
 # Do not print debug messages in production

--- a/src/dguweb/config/prod.secret.exs
+++ b/src/dguweb/config/prod.secret.exs
@@ -21,3 +21,4 @@ config :dguweb, DGUWeb.EctoRepo,
 
 config :tirexs, :uri, "http://127.0.0.1:9200"
 config :dguweb, index: "dgu"
+config :dguweb, upload_path: "/mnt/uploads", host: "dguproto1.northeurope.cloudapp.azure.com"

--- a/src/dguweb/lib/upload/info.ex
+++ b/src/dguweb/lib/upload/info.ex
@@ -3,7 +3,9 @@ defmodule DGUWeb.Upload.Info do
 
     def from_upload(upload) do
         # We have to move this file before the request completes.
-        newpath = "/tmp/#{upload.filename}"
+        root = Application.get_env(:dguweb, :upload_path)
+        newpath = Path.join(root, "#{upload.filename}")
+
         :ok = File.cp(upload.path, newpath)
         {:ok, stat} = File.stat(newpath)
 

--- a/src/dguweb/web/controllers/download_controller.ex
+++ b/src/dguweb/web/controllers/download_controller.ex
@@ -1,0 +1,14 @@
+defmodule DGUWeb.DownloadController do
+  use DGUWeb.Web, :controller
+
+  # Used during development.  In production we'll serve this with nginx
+  def download(conn, %{"path"=>path}) do
+    root = Application.get_env(:dguweb, :upload_path)
+    fullpath =Path.join(root, path)
+
+    conn
+    |> put_resp_header( "Content-type", "application/octet-stream")
+    |> send_file(200, fullpath)
+  end
+
+end

--- a/src/dguweb/web/models/upload.ex
+++ b/src/dguweb/web/models/upload.ex
@@ -39,9 +39,11 @@ defmodule DGUWeb.Upload do
 
     File.rename(file.path, newpath)
 
+    host = Application.get_env(:dguweb, :host)
+
     c = put_change(changeset, :content_type, file.content_type)
     c = put_change(c, :path, newpath)
-    c = put_change(c, :url, "/downloads/#{name}")
+    c = put_change(c, :url, "#{host}/download/#{name}")
 
     c
   end

--- a/src/dguweb/web/router.ex
+++ b/src/dguweb/web/router.ex
@@ -15,6 +15,7 @@ defmodule DGUWeb.Router do
     plug :fetch_flash
     #plug :protect_from_forgery
     plug :put_secure_browser_headers
+
     plug Authentication
   end
 
@@ -29,10 +30,11 @@ defmodule DGUWeb.Router do
     resources "/theme", ThemeController
     resources "/dataset", DatasetController
     resources "/session", SessionController, only: [:new, :create]
-
     resources "/upload", UploadController, only: [:new, :create, :show]
     post "/upload/:id/put", UploadController, :put
     get "/upload/:id/find", UploadController, :find
+
+    get "/download/:path",  DownloadController, :download
 
     get    "/login",  SessionController, :login_view
     post   "/login",  SessionController, :login


### PR DESCRIPTION
Although we'll probably just use nginx for now in prod to serve
downloads, I've added stuff so that:
- Download links will work in development
- Download links take into account the host we're on
- We can control where uploads go..
