### PR TITLE
Fix where uploaded files are moved to.

### DIFF
--- a/src/dguweb/web/models/upload.ex
+++ b/src/dguweb/web/models/upload.ex
@@ -35,7 +35,9 @@ defmodule DGUWeb.Upload do
   defp do_file(changeset, file) do
     [_name, ext] = String.split(file.filename, ".")
     name = "#{UUID.uuid4}.#{ext}"
-    newpath = "/tmp/#{name}"
+
+    newpath = Application.get_env(:dguweb, :upload_path)
+    |> Path.join("#{name}")
 
     File.rename(file.path, newpath)
 


### PR DESCRIPTION
Using phoenix file upload we need to move the file we uploaded before
the end of the request - when it will be deleted.  THis change makes
sure it doesn't move the files to the hard-coded path /tmp.
