### PR TITLE
Move file after upload

### DIFF
--- a/src/dguweb/web/models/upload.ex
+++ b/src/dguweb/web/models/upload.ex
@@ -39,7 +39,8 @@ defmodule DGUWeb.Upload do
     newpath = Application.get_env(:dguweb, :upload_path)
     |> Path.join("#{name}")
 
-    File.rename(file.path, newpath)
+    # File.rename does not work across devices.
+    System.cmd("mv", [file.path, newpath])
 
     host = Application.get_env(:dguweb, :host)
 


### PR DESCRIPTION
Because of aforementioned 'must move file before the end of request' we
have been using File.rename() to move the file.  Unfortunately
File.rename doesn't work across file systems - and sometimes /tmp is
mounted on a different file-system.

Switched to System.cmd() which feels wrong, but works while I find a
better alternative.
