### PR TITLE
Allow upload to create a new dataset.

### DIFF
--- a/src/dguweb/test/controllers/upload_controller_test.exs
+++ b/src/dguweb/test/controllers/upload_controller_test.exs
@@ -2,7 +2,7 @@ defmodule DGUWeb.UploadControllerTest do
   use DGUWeb.ConnCase
 
   alias DGUWeb.Upload
-  alias DGUWeb.{Dataset, Publisher}
+  alias DGUWeb.Publisher
 
   @valid_attrs %{name: "simple", description: "A description", content_type: "some content",
     dataset: nil, errors: [], path: "some content", publisher: "testpub",
@@ -16,7 +16,7 @@ defmodule DGUWeb.UploadControllerTest do
   end
 
   test "creates resource and redirects when data is valid", %{conn: conn} do
-    pub = Repo.insert! %Publisher{name: "testpub", title: "some content",description: "Description", url: "some content"}
+    Repo.insert! %Publisher{name: "testpub", title: "some content",description: "Description", url: "some content"}
     post conn, upload_path(conn, :create), upload: @valid_attrs
     assert Repo.get_by(Upload, description: "A description" )
   end
@@ -27,7 +27,7 @@ defmodule DGUWeb.UploadControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    pub = Repo.insert! %Publisher{name: "testpub", title: "some content",description: "Description", url: "some content"}
+    Repo.insert! %Publisher{name: "testpub", title: "some content",description: "Description", url: "some content"}
 
     cs = Upload.changeset(%Upload{}, @valid_attrs)
     upload = Repo.insert!(cs)

--- a/src/dguweb/web/controllers/dataset_controller.ex
+++ b/src/dguweb/web/controllers/dataset_controller.ex
@@ -75,7 +75,14 @@ defmodule DGUWeb.DatasetController do
   def edit(conn, %{"id" => id}) do
     dataset = Repo.get_by!(Dataset, [name: id])
     changeset = Dataset.changeset(dataset)
-    render(conn, "edit.html", dataset: dataset, changeset: changeset)
+
+    publisher = Repo.get(Publisher, dataset.publisher_id)
+
+    render(conn, "edit.html", dataset: dataset, changeset: changeset,
+        themes: get_themes_for_select,
+        publisher: publisher,
+        upload: nil
+      )
   end
 
   def update(conn, %{"id" => id, "dataset" => dataset_params}) do
@@ -88,7 +95,13 @@ defmodule DGUWeb.DatasetController do
         |> put_flash(:info, "Dataset updated successfully.")
         |> redirect(to: dataset_path(conn, :show, dataset.name))
       {:error, changeset} ->
-        render(conn, "edit.html", dataset: dataset, changeset: changeset)
+        publisher = Repo.get_by(Publisher, id: dataset.publisher_id)
+
+        render(conn, "edit.html", dataset: dataset, changeset: changeset,
+          themes: get_themes_for_select,
+          publisher: publisher,
+          upload: nil
+        )
     end
   end
 

--- a/src/dguweb/web/controllers/dataset_controller.ex
+++ b/src/dguweb/web/controllers/dataset_controller.ex
@@ -3,29 +3,65 @@ defmodule DGUWeb.DatasetController do
 
   alias DGUWeb.Repo
   alias DGUWeb.Dataset
+  alias DGUWeb.Theme
+  alias DGUWeb.Upload
+  alias DGUWeb.Publisher
+  alias DGUWeb.DataFile
 
   def index(conn, _params) do
     datasets = Repo.all(Dataset) |> Repo.preload(:publisher)
     render(conn, "index.html", datasets: datasets)
   end
 
-  def new(conn, _params) do
+  def new(conn, %{"upload"=> upload}=_params) do
     changeset = Dataset.changeset(%Dataset{})
-    render(conn, "new.html", changeset: changeset)
+
+    render(conn, "new.html", changeset: changeset,
+      themes: get_themes_for_select,
+      publisher: get_publisher_from_upload(upload),
+      upload: upload)
   end
 
-  def create(conn, %{"dataset" => dataset_params}) do
+  def create(conn, %{"dataset" => dataset_params, "upload"=> upload}) do
     changeset = Dataset.changeset(%Dataset{}, dataset_params)
 
     case Repo.insert(changeset) do
-      {:ok, _dataset} ->
+      {:ok, dataset} ->
+
+        # Upload the upload and delete
+        # TODO(rdj): Make this a bit more resilient
+        upload_obj = Repo.get(Upload, String.to_integer(upload))
+        cs = DataFile.changeset_from_upload(upload_obj, dataset.id)
+
+        Repo.insert(cs)
+        Repo.delete(upload_obj)
+
         conn
         |> put_flash(:info, "Dataset created successfully.")
-        |> redirect(to: dataset_path(conn, :index))
+        |> redirect(to: dataset_path(conn, :show, dataset.name))
       {:error, changeset} ->
-        render(conn, "new.html", changeset: changeset)
+        render(conn, "new.html", changeset: changeset,
+          themes: get_themes_for_select,
+          publisher: get_publisher_from_upload(upload),
+          upload: upload
+        )
     end
   end
+
+  defp get_themes_for_select() do
+    themes = Repo.all(Theme)
+    |> Enum.map(fn t->
+      {t.title, t.id}
+    end)
+    |> Enum.into([])
+  end
+
+  defp get_publisher_from_upload(upload) do
+    up = Repo.get(Upload, upload)
+    Repo.get_by(Publisher, name: up.publisher)
+  end
+
+
 
   def show(conn, %{"id" => id}) do
     dataset = Repo.get_by!(Dataset, name: id)

--- a/src/dguweb/web/templates/dataset/edit.html.eex
+++ b/src/dguweb/web/templates/dataset/edit.html.eex
@@ -1,6 +1,9 @@
 <h2>Edit dataset</h2>
 
 <%= render "form.html", changeset: @changeset,
-                        action: dataset_path(@conn, :update, @dataset) %>
+                        action: dataset_path(@conn, :update, @dataset),
+                        themes: @themes,
+                        publisher: @publisher,
+                        upload: nil %>
 
 <%= link "Back", to: dataset_path(@conn, :index) %>

--- a/src/dguweb/web/templates/dataset/form.html.eex
+++ b/src/dguweb/web/templates/dataset/form.html.eex
@@ -5,19 +5,29 @@
     </div>
   <% end %>
 
+  <input type="hidden" name="dataset[publisher_id]" value="<%= @publisher.id %>">
+  <input type="hidden" name="upload" value="<%= @upload %>">
+
   <div class="form-group">
-    <%= label f, :name, class: "control-label" %>
+    <%= label f, :name, class: "form-label-bold" %>
     <%= text_input f, :name, class: "form-control" %>
     <%= error_tag f, :name %>
   </div>
 
   <div class="form-group">
-    <%= label f, :title, class: "control-label" %>
+    <%= label f, :title, class: "form-label-bold" %>
     <%= text_input f, :title, class: "form-control" %>
     <%= error_tag f, :title %>
   </div>
 
   <div class="form-group">
-    <%= submit "Submit", class: "btn btn-primary" %>
+    <%= label f, :description, class: "form-label-bold" %>
+    <%= textarea f, :description, class: "form-control", rows: 10 %>
+    <%= error_tag f, :description %>
+  </div>
+
+
+  <div class="form-group">
+    <%= submit "Submit", class: "button" %>
   </div>
 <% end %>

--- a/src/dguweb/web/templates/dataset/new.html.eex
+++ b/src/dguweb/web/templates/dataset/new.html.eex
@@ -1,6 +1,8 @@
-<h2>New dataset</h2>
+<h1 class="heading-xlarge">Add data to new dataset</h1>
 
 <%= render "form.html", changeset: @changeset,
-                        action: dataset_path(@conn, :create) %>
+                        action: dataset_path(@conn, :create),
+                        themes: @themes,
+                        publisher: @publisher,
+                        upload: @upload %>
 
-<%= link "Back", to: dataset_path(@conn, :index) %>


### PR DESCRIPTION
When adding data, the 'Create a new dataset' option now allows users to create a dataset (with minimal metadata).
