### PR TITLE
Ordering was wrong in pattern matching for search

### DIFF
--- a/src/dguweb/web/controllers/search_controller.ex
+++ b/src/dguweb/web/controllers/search_controller.ex
@@ -5,14 +5,12 @@ defmodule DGUWeb.SearchController do
     render conn, :index
   end
 
-
-  def search(conn, %{}), do: showall(conn)
   def search(conn, %{"q" => ""}), do: showall(conn)
-
   def search(conn, %{"q" => query}) do
     result = URI.encode(query) |> Repo.search
     render conn, :search, query: query, results: result.hits.hits, total: result.hits.total
   end
+  def search(conn, %{}), do: showall(conn)
 
 
   defp showall(conn) do


### PR DESCRIPTION
Makes sure we pattern match in the correct order so we don't always return ALL results.
