### PR TITLE
Adds a truncate_text command that is available to all templates

### DIFF
--- a/src/dguweb/lib/util/truncation.ex
+++ b/src/dguweb/lib/util/truncation.ex
@@ -1,0 +1,29 @@
+defmodule DGUWeb.Util.Truncation do
+
+  @length 140
+
+
+  def truncate(text) when byte_size(text) < @length, do: text
+
+  def truncate(text) do
+    text
+    |> String.strip
+    |> truncate_at(".")
+    |> truncate_at("\n")
+    |> truncate_at(@length)
+  end
+
+  def truncate_at(text, pos) when is_integer(pos) and byte_size(text) < @length, do: text
+
+  def truncate_at(text, pos) when is_integer(pos) and byte_size(text) >= @length do
+   String.slice(text, 0..(pos-4)) <> "..."
+ end
+
+  def truncate_at(text, sep) when byte_size(text) < @length, do: text
+
+  def truncate_at(text, sep) do
+    [start|_] = String.split(text, sep)
+    start
+  end
+
+end

--- a/src/dguweb/test/lib/truncation_test.exs
+++ b/src/dguweb/test/lib/truncation_test.exs
@@ -1,0 +1,46 @@
+defmodule DGUWeb.TruncationTest do
+  use ExUnit.Case
+  alias DGUWeb.Util.Truncation, as: T
+
+  @long """
+    An archive of historic contract data from the Business Link Contracts Finder website that closed in February 2015. The
+    archive includes public sector contract tenders and contracts awarded between 11/2/2011 and 25/2/2015. The archive was
+    superseded by a new Contracts Finder designed and operated by the Crown Commercial Service:
+    https://www.gov.uk/contracts-finder This archive has been provided by the data.gov.uk team using data from the Crown
+    Commercial Service. The data behind the Contracts Finder Archive is provided as a complete database dump (in SQLite3
+    format), including all the contracts (notices) and awards. It excludes the Word documents and other attachments to the notices
+  """
+
+  @vlong_no_punc """
+    An archive of historic contract data from the Business Link Contracts Finder website that closed in February 2015
+    and The archive includes public sector contract tenders and contracts awarded between 11/2/2011 and 25/2/2015 The archive
+    was superseded by a new Contracts Finder designed and operated by the Crown Commercial Service:
+    https://www.gov.uk/contracts-finder This archive has been provided by the data.gov.uk team using data from the Crown
+    Commercial Service. The data behind the Contracts Finder Archive is provided as a complete database dump (in SQLite3
+    format), including all the contracts (notices) and awards. It excludes the Word documents and other attachments to the notices
+  """
+
+  @lots_of_text "An archive of historic contract data from the Business Link Contracts Finder website that closed in February 2015 and The archive includes public sector contract tenders and contracts awarded between 11/2/2011 and 25/2/2015 The archive was superseded by a new Contracts Finder designed and operated by the Crown Commercial Service:"
+
+  test "doesn't truncate when unnecessary" do
+    assert T.truncate("A small sentence") == "A small sentence"
+  end
+
+  test "returns first sentence" do
+    assert T.truncate(@long) == "An archive of historic contract data from the Business Link Contracts Finder website that closed in February 2015"
+  end
+
+  test "finds a newline" do
+    assert T.truncate(@vlong_no_punc) == "An archive of historic contract data from the Business Link Contracts Finder website that closed in February 2015"
+  end
+
+  test "ellipsis if nothing else" do
+    res = T.truncate(@lots_of_text)
+
+    assert String.length(res) == 140
+    assert res == """
+    An archive of historic contract data from the Business Link Contracts Finder website that closed in February 2015 and The archive include...
+    """ |> String.strip
+  end
+
+end

--- a/src/dguweb/web/helpers.ex
+++ b/src/dguweb/web/helpers.ex
@@ -1,3 +1,8 @@
 defmodule DGUWeb.TemplateHelpers do
 
+
+  # Truncates text to 140 characters either at the first ., the first \n or at 137
+  # chars <> "..."
+  def truncate_text(text), do: DGUWeb.Util.Truncation.truncate(text)
+
 end

--- a/src/dguweb/web/web.ex
+++ b/src/dguweb/web/web.ex
@@ -53,6 +53,7 @@ defmodule DGUWeb.Web do
       import DGUWeb.ErrorHelpers
       import DGUWeb.Gettext
       import DGUWeb.Session, only: [logged_in?: 1]
+      import DGUWeb.TemplateHelpers
     end
   end
 


### PR DESCRIPTION
For places where displaying the whole description is a little too much
data, you can now used <%= truncate_text(@dataset.description) %> which will trim it down to less than 140 chars, this will be either:
- At the first full stop.
- At the first newline
- At 137 character with "..." appended.

It is likely that at some point it would make more sense for this to be
done as part of creating/updating the dataset.

Fixes #64 
