### PR TITLE
Use resource_create instead of updating the whole package

### DIFF
--- a/src/dguweb/lib/ckan/client.ex
+++ b/src/dguweb/lib/ckan/client.ex
@@ -37,6 +37,7 @@ defmodule DGUWeb.CKAN.Client do
     {:post, :package_create, %{}, ""},
     {:post, :package_update, %{}, ""},
     {:post, :package_delete, [], ""},
+    {:post, :resource_create, %{}, ""},
   ]
 
   def new(server, api_key \\ nil) do

--- a/src/dguweb/web/controllers/publisher_controller.ex
+++ b/src/dguweb/web/controllers/publisher_controller.ex
@@ -40,7 +40,6 @@ defmodule DGUWeb.PublisherController do
 
   def show_publisher(conn, publisher, page_number) do
     page_number = if page_number < 1, do: 1, else: page_number
-    IO.inspect page_number
     offset = case page_number do
       1 ->
          0

--- a/src/dguweb/web/models/dataset.ex
+++ b/src/dguweb/web/models/dataset.ex
@@ -26,17 +26,13 @@ defmodule DGUWeb.Dataset do
     dataset = show(conn, dataset_name)
 
     r = resource_from_upload(upload_obj)
-    resources = [r|dataset.resources] |> Enum.reverse
-
-    dataset = dataset
-    |> Map.put(:resources, resources)
-    |> Map.delete(:extras)
-    |> Map.delete(:tags)
-    |> Map.delete(:codelist)
-    |> Map.delete(:schema)
+    |> Map.put(:package_id, dataset_name)
 
     call = conn.assigns[:ckan]
-    |> Client.package_update(dataset)
+    |> Client.resource_create(r)
+
+    key = "package_show:#{dataset_name}"
+    Cachex.del(:request_cache, key)
 
     call
   end


### PR DESCRIPTION
Rather than update the dataset directly, just create a resource that points at it.  It still call package_update behind the scenes, but it is a lot simpler for us to add a resource.
