### PR TITLE
Makes the app translatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,15 @@ Until authentication is addressed you must perform a manual step to set up your 
 3. In the dguweb_dev database you need to assign these API keys to users who have registered in the prototype front-end. You can do this in the public.users table in the dguweb_dev database.
 
 Once this is complete, when users log in to the prototype the list of organisations they can manage is retrieved and stored against their connection so that user and permitted organisations are available to the prototype.
+
+
+## Translations
+
+It's kind of nice to be able to provide translations into languages used in the UK - such as Welsh.
+
+To re-generate the PO files use ```mix gettext.extract --merge```.
+
+To make something translatable, use ```<%= gettext "My text string" %>```
+
+You can test for now by passing ```?locale=en``` as a querystring until we provide a proper route.
+

--- a/src/dguweb/priv/gettext/cy/LC_MESSAGES/default.po
+++ b/src/dguweb/priv/gettext/cy/LC_MESSAGES/default.po
@@ -1,0 +1,35 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: cy\n"
+
+#: web/templates/layout/app.html.eex:88
+msgid "Organisations"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:57
+msgid "Skip to main content"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:89
+msgid "Datasets"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:94
+msgid "Logged in as"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:95
+msgid "Sign out"
+msgstr ""
+
+#: web/templates/dataset/show.html.eex:22
+msgid "Add Data"
+msgstr ""

--- a/src/dguweb/priv/gettext/cy/LC_MESSAGES/errors.po
+++ b/src/dguweb/priv/gettext/cy/LC_MESSAGES/errors.po
@@ -1,48 +1,42 @@
-## This file is a PO Template file.
+## `msgid`s in this file come from POT (.pot) files.
 ##
-## `msgid`s here are often extracted from source code.
-## Add new translations manually only if they're dynamic
-## translations that can't be statically extracted.
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
 ##
-## Run `mix gettext.extract` to bring this file up to
-## date. Leave `msgstr`s empty as changing them here as no
-## effect: edit them in PO (`.po`) files instead.
-## From Ecto.Changeset.cast/4
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: cy\n"
+
 msgid "can't be blank"
 msgstr ""
 
-## From Ecto.Changeset.unique_constraint/3
 msgid "has already been taken"
 msgstr ""
 
-## From Ecto.Changeset.put_change/3
 msgid "is invalid"
 msgstr ""
 
-## From Ecto.Changeset.validate_format/3
 msgid "has invalid format"
 msgstr ""
 
-## From Ecto.Changeset.validate_subset/3
 msgid "has an invalid entry"
 msgstr ""
 
-## From Ecto.Changeset.validate_exclusion/3
 msgid "is reserved"
 msgstr ""
 
-## From Ecto.Changeset.validate_confirmation/3
 msgid "does not match confirmation"
 msgstr ""
 
-## From Ecto.Changeset.no_assoc_constraint/3
 msgid "is still associated to this entry"
 msgstr ""
 
 msgid "are still associated to this entry"
 msgstr ""
 
-## From Ecto.Changeset.validate_length/3
 msgid "should be %{count} character(s)"
 msgid_plural "should be %{count} character(s)"
 msgstr[0] ""
@@ -73,7 +67,6 @@ msgid_plural "should have at most %{count} item(s)"
 msgstr[0] ""
 msgstr[1] ""
 
-## From Ecto.Changeset.validate_number/3
 msgid "must be less than %{number}"
 msgstr ""
 

--- a/src/dguweb/priv/gettext/default.pot
+++ b/src/dguweb/priv/gettext/default.pot
@@ -1,0 +1,36 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+"Language: INSERT LANGUAGE HERE\n"
+
+#: web/templates/layout/app.html.eex:88
+msgid "Organisations"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:57
+msgid "Skip to main content"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:89
+msgid "Datasets"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:94
+msgid "Logged in as"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:95
+msgid "Sign out"
+msgstr ""
+
+#: web/templates/dataset/show.html.eex:22
+msgid "Add Data"
+msgstr ""

--- a/src/dguweb/priv/gettext/en/LC_MESSAGES/default.po
+++ b/src/dguweb/priv/gettext/en/LC_MESSAGES/default.po
@@ -1,0 +1,35 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+
+#: web/templates/layout/app.html.eex:88
+msgid "Organisations"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:57
+msgid "Skip to main content"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:89
+msgid "Datasets"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:94
+msgid "Logged in as"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:95
+msgid "Sign out"
+msgstr ""
+
+#: web/templates/dataset/show.html.eex:22
+msgid "Add Data"
+msgstr ""

--- a/src/dguweb/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/src/dguweb/priv/gettext/fr/LC_MESSAGES/default.po
@@ -1,0 +1,35 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+
+#: web/templates/layout/app.html.eex:88
+msgid "Organisations"
+msgstr "Producteur"
+
+#: web/templates/layout/app.html.eex:57
+msgid "Skip to main content"
+msgstr ""
+
+#: web/templates/layout/app.html.eex:89
+msgid "Datasets"
+msgstr "Données"
+
+#: web/templates/layout/app.html.eex:94
+msgid "Logged in as"
+msgstr "Connecté en que"
+
+#: web/templates/layout/app.html.eex:95
+msgid "Sign out"
+msgstr "Se déconnecter"
+
+#: web/templates/dataset/show.html.eex:22
+msgid "Add Data"
+msgstr "Ajouter des données"

--- a/src/dguweb/priv/gettext/fr/LC_MESSAGES/errors.po
+++ b/src/dguweb/priv/gettext/fr/LC_MESSAGES/errors.po
@@ -1,48 +1,42 @@
-## This file is a PO Template file.
+## `msgid`s in this file come from POT (.pot) files.
 ##
-## `msgid`s here are often extracted from source code.
-## Add new translations manually only if they're dynamic
-## translations that can't be statically extracted.
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
 ##
-## Run `mix gettext.extract` to bring this file up to
-## date. Leave `msgstr`s empty as changing them here as no
-## effect: edit them in PO (`.po`) files instead.
-## From Ecto.Changeset.cast/4
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: fr\n"
+
 msgid "can't be blank"
 msgstr ""
 
-## From Ecto.Changeset.unique_constraint/3
 msgid "has already been taken"
 msgstr ""
 
-## From Ecto.Changeset.put_change/3
 msgid "is invalid"
 msgstr ""
 
-## From Ecto.Changeset.validate_format/3
 msgid "has invalid format"
 msgstr ""
 
-## From Ecto.Changeset.validate_subset/3
 msgid "has an invalid entry"
 msgstr ""
 
-## From Ecto.Changeset.validate_exclusion/3
 msgid "is reserved"
 msgstr ""
 
-## From Ecto.Changeset.validate_confirmation/3
 msgid "does not match confirmation"
 msgstr ""
 
-## From Ecto.Changeset.no_assoc_constraint/3
 msgid "is still associated to this entry"
 msgstr ""
 
 msgid "are still associated to this entry"
 msgstr ""
 
-## From Ecto.Changeset.validate_length/3
 msgid "should be %{count} character(s)"
 msgid_plural "should be %{count} character(s)"
 msgstr[0] ""
@@ -73,7 +67,6 @@ msgid_plural "should have at most %{count} item(s)"
 msgstr[0] ""
 msgstr[1] ""
 
-## From Ecto.Changeset.validate_number/3
 msgid "must be less than %{number}"
 msgstr ""
 

--- a/src/dguweb/web/plugs/locale.ex
+++ b/src/dguweb/web/plugs/locale.ex
@@ -1,0 +1,14 @@
+defmodule DGUWeb.Plugs.Locale do
+  import Plug.Conn
+
+  def init(opts), do: nil
+
+  def call(conn, _opts) do
+    case conn.params["locale"] || get_session(conn, :locale) do
+      nil     -> conn
+      locale  ->
+        Gettext.put_locale(DGUWeb.Gettext, locale)
+        conn |> put_session(:locale, locale)
+    end
+  end
+end

--- a/src/dguweb/web/router.ex
+++ b/src/dguweb/web/router.ex
@@ -1,8 +1,6 @@
 defmodule DGUWeb.Router do
   use DGUWeb.Web, :router
 
-  alias DGUWeb.Plugs.Authentication
-
   pipeline :browser do
     plug :accepts, ["html", "json"]
     plug :fetch_session
@@ -10,7 +8,8 @@ defmodule DGUWeb.Router do
     #plug :protect_from_forgery
     plug :put_secure_browser_headers
 
-    plug Authentication
+    plug DGUWeb.Plugs.Locale
+    plug DGUWeb.Plugs.Authentication
   end
 
   scope "/", DGUWeb do

--- a/src/dguweb/web/templates/dataset/show.html.eex
+++ b/src/dguweb/web/templates/dataset/show.html.eex
@@ -19,7 +19,7 @@
 
     <div class="column-one-third">
        <%= if @dataset.organization && user_in_publisher(@conn, @dataset.organization.name) do %>
-            <a class="button" href="/upload/new?dataset=<%= @dataset.name %>">Add Data</a>
+            <a class="button" href="/upload/new?dataset=<%= @dataset.name %>"><%= gettext "Add Data" %></a>
             <br/> <br/>
         <% end %>
     </div>

--- a/src/dguweb/web/templates/layout/app.html.eex
+++ b/src/dguweb/web/templates/layout/app.html.eex
@@ -54,7 +54,7 @@
 
   <div id="skiplink-container">
     <div>
-      <a href="#content" class="skiplink">Skip to main content</a>
+      <a href="#content" class="skiplink"><%= gettext "Skip to main content" %></a>
     </div>
   </div>
 
@@ -85,13 +85,14 @@
   <nav>
     <ul>
       <li><a href="/">Home</a></li>
-      <li><a href="/publisher">Organisations</a></li>
+      <li><a href="/publisher"><%= gettext "Organisations" %></a></li>
+      <li><a href="/search"><%= gettext "Datasets" %></a></li>
     </ul>
   </nav>
   <%= if logged_in?(@conn) do %>
     <ul class="login-info">
-      <li>Logged in as <a href="<%= user_path(@conn, :index) %>"><%= @conn.assigns[:current_user].username %></a></li>
-      <li><%= link "Sign out", to: session_path(@conn, :logout) %></li>
+      <li><%= gettext "Logged in as" %> <a href="<%= user_path(@conn, :index) %>"><%= @conn.assigns[:current_user].username %></a></li>
+      <li><%= link gettext("Sign out"), to: session_path(@conn, :logout) %></li>
     </ul>
   <% end %>
 </div>


### PR DESCRIPTION
Shows how the app can be translatable with some (bad) French
translations when you pass ?locale=fr - chose French in case someone wanted to translate some more words :) 

CY seems like an obvious choice to do this if we can find a welsh speaker to help translate.

Before #85 is done we need to get `<%= gettext "string" %>` to all
of the relevant places and find translations.
