### PR TITLE
Make the search boxes translatable

### DIFF
--- a/src/dguweb/web/static/elm/SearchBox.elm
+++ b/src/dguweb/web/static/elm/SearchBox.elm
@@ -32,8 +32,9 @@ port hitReturn : String -> Cmd msg
 
 
 type alias Flags =
-    { initialSearchQuery: String
-    , placeholder: String }
+    { initialSearchQuery : String
+    , placeholder : String
+    }
 
 
 type alias Dataset =
@@ -48,7 +49,7 @@ type alias Model =
     , selectedIndex : Int
     , visible : Bool
     , searchQuery : String
-    , placeholder: String
+    , placeholder : String
     }
 
 
@@ -141,11 +142,12 @@ searchApiDecoder =
 
 viewCompletionItem : Int -> Int -> Dataset -> Html Msg
 viewCompletionItem liIdx selectedIdx result =
-    let attribs =
-        if liIdx == selectedIdx then
-            [ class "selected" ]
-        else
-            []
+    let
+        attribs =
+            if liIdx == selectedIdx then
+                [ class "selected" ]
+            else
+                []
     in
         Html.li
             attribs
@@ -211,5 +213,5 @@ view model =
             , viewCompletionMenu model
             ]
          else
-            [ viewForm model.searchQuery model.placeholder]
+            [ viewForm model.searchQuery model.placeholder ]
         )

--- a/src/dguweb/web/static/elm/SearchBox.elm
+++ b/src/dguweb/web/static/elm/SearchBox.elm
@@ -32,7 +32,8 @@ port hitReturn : String -> Cmd msg
 
 
 type alias Flags =
-    { initialSearchQuery: String }
+    { initialSearchQuery: String
+    , placeholder: String }
 
 
 type alias Dataset =
@@ -47,12 +48,13 @@ type alias Model =
     , selectedIndex : Int
     , visible : Bool
     , searchQuery : String
+    , placeholder: String
     }
 
 
 init : Flags -> ( Model, Cmd Msg )
 init flags =
-    ( Model [] -1 False flags.initialSearchQuery, Cmd.none )
+    ( Model [] -1 False flags.initialSearchQuery flags.placeholder, Cmd.none )
 
 
 
@@ -165,8 +167,8 @@ viewCompletionMenu model =
         ]
 
 
-viewForm : String -> Html Msg
-viewForm queryString =
+viewForm : String -> String -> Html Msg
+viewForm queryString placeholderString =
     let
         keydownOptions =
             { preventDefault = True, stopPropagation = False }
@@ -191,7 +193,7 @@ viewForm queryString =
             [ id "q"
             , name "q"
             , type' "text"
-            , placeholder "Search for data"
+            , placeholder placeholderString
             , class "form-control search"
             , autocomplete False
             , onInput Lookup
@@ -205,9 +207,9 @@ view : Model -> Html Msg
 view model =
     Html.div []
         (if model.visible && List.length model.datasets > 0 then
-            [ viewForm model.searchQuery
+            [ viewForm model.searchQuery model.placeholder
             , viewCompletionMenu model
             ]
          else
-            [ viewForm model.searchQuery ]
+            [ viewForm model.searchQuery model.placeholder]
         )

--- a/src/dguweb/web/static/js/app.js
+++ b/src/dguweb/web/static/js/app.js
@@ -24,10 +24,11 @@ import "phoenix_html"
 const searchBoxElement = document.querySelector('#search-box');
 
 if (searchBoxElement) {
-  var searchQuery = searchBoxElement.querySelector('input').value;
+  var searchBox = searchBoxElement.querySelector('input')
+  var searchQuery = searchBox.value;
   searchBoxElement.innerHTML = '';
   const searchBox =
-    Elm.SearchBox.embed(searchBoxElement, { initialSearchQuery: searchQuery });
+    Elm.SearchBox.embed(searchBoxElement, { initialSearchQuery: searchQuery, placeholder: searchBox.placeholder });
 
   // called when return key hit in the form
   searchBox.ports.hitReturn.subscribe(selector => {


### PR DESCRIPTION
An attempt to pass the placeholder text from the page to the elm
searchbox so that it can pick up translated text.

Not sure if passing this through in the initial flags is the best one ...
