### PR TITLE
Display the most recent Junior Organogram data as a preview.

### DIFF
--- a/src/dguweb/mix.exs
+++ b/src/dguweb/mix.exs
@@ -47,7 +47,7 @@ defmodule DGUWeb.Mixfile do
      {:cowboy, "~> 1.0"},
      {:httpoison, "~> 0.9.0"},
      {:comeonin, "~> 2.5"},
-     {:csv, "~> 1.4.0"},
+     {:csv, "~> 1.4.2"},
      {:uuid, "~> 1.1" },
      {:cachex, "~> 1.2"},
      {:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.2"},

--- a/src/dguweb/mix.lock
+++ b/src/dguweb/mix.lock
@@ -28,6 +28,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
+  "nimble_csv": {:hex, :nimble_csv, "0.1.0", "b988ab0eeac9ca5980780b76a4a217b2ec943b2debaf50b0ccf0cd1a6c4adf56", [:mix], []},
   "parallel_stream": {:hex, :parallel_stream, "1.0.5", "4c78d3e675f9eff885cbe252c89a8fc1d2fb803c0d03a914281e587834e09431", [:mix], []},
   "phoenix": {:hex, :phoenix, "1.2.0", "1bdeb99c254f4c534cdf98fd201dede682297ccc62fcac5d57a2627c3b6681fb", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "phoenix_ecto": {:hex, :phoenix_ecto, "3.0.1", "42eb486ef732cf209d0a353e791806721f33ff40beab0a86f02070a5649ed00a", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: false]}, {:phoenix_html, "~> 2.6", [hex: :phoenix_html, optional: true]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},

--- a/src/dguweb/web/templates/dataset/organogram_table.html.eex
+++ b/src/dguweb/web/templates/dataset/organogram_table.html.eex
@@ -1,0 +1,20 @@
+<h1 class="heading-large">Organogram - <%= @type %></h1>
+
+<table>
+    <thead>
+        <tr>
+            <%= for header <- @organogram_header do %>
+            <th><%= header %></th>
+            <%= end %>
+        </tr>
+    </thead>
+    <tbody>
+        <%= for row <- @organogram_data do %>
+        <tr>
+            <%= for cell <- row do %>
+            <td><%= cell %></td>
+            <%= end %>
+        </tr>
+        <%= end %>
+    </tbody>
+</table>

--- a/src/dguweb/web/templates/dataset/show.html.eex
+++ b/src/dguweb/web/templates/dataset/show.html.eex
@@ -27,7 +27,11 @@
     <hr/>
 </div>
 
-
+<%= if @organogram_data do %>
+<div class="grid-row" style="overflow-x: scroll;">
+    <%= render "organogram_table.html", organogram_data: @organogram_data, type: "Junior Posts", organogram_header: @organogram_header %>
+</div>
+<%= end %>
 
 <div class="grid-row">
 


### PR DESCRIPTION
When a dataset is shown that has 'organogram' in the title, then the
first CSV listed for Junior Staff is fetched and rendered to the page.
The data is rendered in templates/dataset/organogram_table.html.eex and currently the containing div in templates/dataset/show.html.eex uses overflow to show the scrollbar - this might not be great.

The next step (PR) is to do this for Senior Posts as well, and perhaps consider some error handling. And caching. Definitely need some caching.
