### PR TITLE
Allow users to switch between Junior and Senior posts in Organogram

### DIFF
--- a/src/dguweb/web/controllers/dataset_controller.ex
+++ b/src/dguweb/web/controllers/dataset_controller.ex
@@ -82,14 +82,18 @@ defmodule DGUWeb.DatasetController do
   end
 
   def render_dataset(conn, dataset, true) do
-    # Junior for now
+
+    find_type = Map.get(conn.query_params, "organogram", "junior")
+
     url_map = dataset.resources
-    |> Enum.find(fn x-> String.contains?(x.description, "Junior") end)
+    |> Enum.find(fn x->
+      x.description |> String.downcase |> String.contains?(find_type)
+    end)
 
     {header,rows} = case url_map do
       nil ->
         {nil, nil}
-      u ->
+      _ ->
         url = Map.get(url_map, :url)
         response = HTTPotion.get url, [timeout: 20_000]
 
@@ -104,11 +108,12 @@ defmodule DGUWeb.DatasetController do
 
     render(conn, "show.html", dataset: dataset,
       organogram_header: header,
-      organogram_data: rows)
+      organogram_data: rows,
+      organogram_type: String.capitalize(find_type))
   end
 
   def render_dataset(conn, dataset, _) do
-    render(conn, "show.html", dataset: dataset, organogram_data: nil)
+    render(conn, "show.html", dataset: dataset, organogram_data: nil, organogram_type: nil)
   end
 
   def edit(conn, %{"id" => id}) do

--- a/src/dguweb/web/templates/dataset/organogram_table.html.eex
+++ b/src/dguweb/web/templates/dataset/organogram_table.html.eex
@@ -1,4 +1,11 @@
-<h1 class="heading-large">Organogram - <%= @type %></h1>
+<h1 id="organogram" class="heading-large">Organogram - <%= @type %> Posts</h1>
+
+<%= if @type == "Junior" do %>
+    <a href="<%= dataset_path(@conn, :show, @dataset.name, organogram: "senior") %>#organogram">Show Senior Posts</a>
+<%= else %>
+        <a href="<%= dataset_path(@conn, :show, @dataset.name, organogram: "junior") %>#organogram">Show Junior Posts</a>
+<%= end %>
+
 
 <table>
     <thead>

--- a/src/dguweb/web/templates/dataset/show.html.eex
+++ b/src/dguweb/web/templates/dataset/show.html.eex
@@ -29,7 +29,7 @@
 
 <%= if @organogram_data do %>
 <div class="grid-row" style="overflow-x: scroll;">
-    <%= render "organogram_table.html", organogram_data: @organogram_data, type: "Junior Posts", organogram_header: @organogram_header %>
+    <%= render "organogram_table.html", organogram_data: @organogram_data, type: @organogram_type, organogram_header: @organogram_header, dataset: @dataset, conn: @conn %>
 </div>
 <%= end %>
 


### PR DESCRIPTION
 Best seen at
 /dataset/organogram-staff-salaries-northern-lighthouse-board this PR
 allows users viewing an organogram dataset to switch between viewing
 the Junior Posts (the default) and the Senior Posts.

After applying this you should run

```
mix deps.clean csv 
mix deps.get 
mix deps.compile
mix ecto.migrate
```
