### PR TITLE
Add some stats to the publisher page intended for drill-down.

### DIFF
--- a/src/dguweb/config/dev.exs
+++ b/src/dguweb/config/dev.exs
@@ -27,7 +27,8 @@ config :dguweb, DGUWeb.Endpoint,
   ]
 
 # Where is CKAN?
-config :dguweb, ckan: "http://192.168.10.10:8080"
+#config :dguweb, ckan: "http://192.168.10.10:8080"
+config :dguweb, ckan: "https://test.data.gov.uk"
 config :dguweb, index: "dgu_dev"
 
 # Do not include metadata nor timestamps in development logs

--- a/src/dguweb/lib/ckan/client.ex
+++ b/src/dguweb/lib/ckan/client.ex
@@ -31,6 +31,8 @@ defmodule DGUWeb.CKAN.Client do
     {:get, :user_list, [], ""},
     {:get, :package_search, [], ""},
 
+    {:get, :report_data_get, [], ""},
+
     # Requires an authed user
     {:get, :organization_list_for_user, [], ""},
 

--- a/src/dguweb/web/controllers/publisher_controller.ex
+++ b/src/dguweb/web/controllers/publisher_controller.ex
@@ -1,7 +1,7 @@
 defmodule DGUWeb.PublisherController do
   use DGUWeb.Web, :controller
 
-  alias DGUWeb.{Publisher, Dataset}
+  alias DGUWeb.{Publisher, Dataset, PossibleLink}
   alias DGUWeb.Util.Pagination
 
   def index(conn, _params) do
@@ -40,13 +40,20 @@ defmodule DGUWeb.PublisherController do
         ((other * 10) - 10)
     end
 
+    query= from p in PossibleLink,
+         select: count(p.id),
+         where: p.publisher_name == ^publisher.name
+    possible = Repo.one(query)
+    IO.inspect possible
+
     broken = DGUWeb.Report.broken_links(conn, publisher.name)
 
     response = Dataset.search(conn, "", [fq: "organization:#{publisher.name}", rows: 10, start: offset])
     pagination = Pagination.create(response.count)
 
     render(conn, "show.html", publisher: publisher, datasets: response.results,
-      pagination: pagination, page_number: page_number, offset: offset, broken: broken)
+      pagination: pagination, page_number: page_number, offset: offset, broken: broken,
+      possible: possible)
   end
 
 

--- a/src/dguweb/web/controllers/publisher_controller.ex
+++ b/src/dguweb/web/controllers/publisher_controller.ex
@@ -21,6 +21,7 @@ defmodule DGUWeb.PublisherController do
   def show(conn, %{"id" => id}=params) do
     publisher = Publisher.show(conn, id)
     page_number = get_page_number(params)
+
     show_publisher(conn, publisher, page_number)
   end
 
@@ -39,11 +40,13 @@ defmodule DGUWeb.PublisherController do
         ((other * 10) - 10)
     end
 
+    broken = DGUWeb.Report.broken_links(conn, publisher.name)
+
     response = Dataset.search(conn, "", [fq: "organization:#{publisher.name}", rows: 10, start: offset])
     pagination = Pagination.create(response.count)
 
     render(conn, "show.html", publisher: publisher, datasets: response.results,
-      pagination: pagination, page_number: page_number, offset: offset)
+      pagination: pagination, page_number: page_number, offset: offset, broken: broken)
   end
 
 

--- a/src/dguweb/web/models/report.ex
+++ b/src/dguweb/web/models/report.ex
@@ -1,0 +1,15 @@
+defmodule DGUWeb.Report do
+
+  alias DGUWeb.CKAN.Client
+
+  def broken_links(conn, publisher_shortname) do
+    results = conn.assigns[:ckan]
+    |> Client.report_data_get(id: "broken-links")
+    |> Map.get(:result)
+    |> hd
+    |> Map.get(:table)
+    |> Enum.find(fn x-> x.organization_name == publisher_shortname end)
+  end
+
+
+end

--- a/src/dguweb/web/models/report.ex
+++ b/src/dguweb/web/models/report.ex
@@ -3,7 +3,7 @@ defmodule DGUWeb.Report do
   alias DGUWeb.CKAN.Client
 
   def broken_links(conn, publisher_shortname) do
-    results = conn.assigns[:ckan]
+    conn.assigns[:ckan]
     |> Client.report_data_get(id: "broken-links")
     |> Map.get(:result)
     |> hd

--- a/src/dguweb/web/templates/publisher/show.html.eex
+++ b/src/dguweb/web/templates/publisher/show.html.eex
@@ -14,12 +14,59 @@
             </p>
         <% end %>
 
-        <h2 class="heading-large">Statistics</h2>
-        <p>
-          <%= @broken.broken_resource_count %> out of <%= @broken.resource_count %> links in <%= @broken.broken_package_count %> datasets are broken.
-        </p>
+        <h2 class="heading-large"><%= gettext("Statistics") %></h2>
 
-        <h2 class="heading-large"><%= gettext "Datasets" %></h2>
+        <div class="grid-row">
+          <div class="column-one-third">
+            <div class="data">
+              <h2 class="bold-xxlarge"><a href="#datasets"><%= @broken.package_count %></a></h2>
+              <p class="bold-xsmall"><%= gettext("Datasets") %></p>
+            </div>
+          </div>
+
+          <div class="column-one-third">
+            <div class="data">
+              <h2 class="bold-xxlarge"><a href="#datasets"><%= @broken.resource_count %></a></h2>
+              <p class="bold-xsmall"><%= gettext("Links") %></p>
+            </div>
+          </div>
+
+          <div class="column-one-third">
+            <div class="data">
+              <h2 class="bold-xxlarge"><a href="#datasets"><%= @broken.broken_resource_count %></a></h2>
+              <p class="bold-xsmall"><%= gettext("Broken Links") %></p>
+            </div>
+          </div>
+        </div>
+
+
+        <div class="grid-row">
+          <div class="column-one-half">
+            <div class="data">
+              <h2 class="bold-xxlarge"><a href="#datasets"><%= :rand.uniform(50) %></a></h2>
+              <p class="bold-xsmall"><%= gettext("Appeared in search results (30 days)") %></p>
+            </div>
+          </div>
+
+          <div class="column-one-half">
+            <div class="data">
+              <h2 class="bold-xxlarge"><a href="#datasets"><%= :rand.uniform(10) %></a></h2>
+              <p class="bold-xsmall"><%= gettext("Appeared in search results (7 days)") %></p>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid-row">
+          <div class="column-two-thirds">
+            <div class="data">
+              <h2 class="bold-xxlarge"><a href="#datasets"><%= @possible %></a></h2>
+              <p class="bold-xsmall"><%= gettext("Possible Open Data resources found on website") %></p>
+            </div>
+          </div>
+        </div>
+
+
+        <h2 id="datasets" class="heading-large"><%= gettext "Datasets" %></h2>
         <p>
 <%= gettext "Showing %{start} - %{end} of %{total}", start: @offset + 1, end: @offset + length(@datasets), total: @pagination.total%>
         <ul class="dataset-list">

--- a/src/dguweb/web/templates/publisher/show.html.eex
+++ b/src/dguweb/web/templates/publisher/show.html.eex
@@ -14,6 +14,11 @@
             </p>
         <% end %>
 
+        <h2 class="heading-large">Statistics</h2>
+        <p>
+          <%= @broken.broken_resource_count %> out of <%= @broken.resource_count %> links in <%= @broken.broken_package_count %> datasets are broken.
+        </p>
+
         <h2 class="heading-large"><%= gettext "Datasets" %></h2>
         <p>
 <%= gettext "Showing %{start} - %{end} of %{total}", start: @offset + 1, end: @offset + length(@datasets), total: @pagination.total%>
@@ -30,6 +35,7 @@
               </li>
             <% end %>
         </ul>
+
 
         <%= if @pagination.page_count > 1 do %>
             <p class="pagination">Page <%= @page_number %> of <%= @pagination.page_count %>


### PR DESCRIPTION
Adds some potentially useful numbers (some are made up, some are real) for each
publisher home page.  Each of the numbers in the statistics section
should be a link, but the actual link will need another PR after we have
built the drill-down pages.

This may not be the correct place for this info, but we can always move
it later.

Numbers may be inaccurate while the search index is rebuilding.
