### PR TITLE
UI for Data Links found on publisher website

### DIFF
--- a/src/dguweb/priv/repo/migrations/20160927132155_update_possible_link.exs
+++ b/src/dguweb/priv/repo/migrations/20160927132155_update_possible_link.exs
@@ -1,0 +1,10 @@
+defmodule DGUWeb.Repo.Migrations.CreatePossibleLink do
+  use Ecto.Migration
+
+  def change do
+    alter table(:possible_links) do
+      add :processed, :boolean
+    end
+
+  end
+end

--- a/src/dguweb/test/controllers/possible_link_controller_test.exs
+++ b/src/dguweb/test/controllers/possible_link_controller_test.exs
@@ -1,0 +1,21 @@
+defmodule DGUWeb.PossibleLinkControllerTest do
+  use DGUWeb.ConnCase
+
+  alias DGUWeb.PossibleLink
+  @valid_attrs %{}
+  @invalid_attrs %{}
+
+  test "shows chosen resource", %{conn: conn} do
+    conn = get conn, possible_link_path(conn, :show, "cabinet-office")
+    assert html_response(conn, 200) =~ "Show possible link"
+  end
+
+
+  test "deletes chosen resource", %{conn: conn} do
+    possible_link = Repo.insert! %PossibleLink{url: "", publisher_name: "cabinet-office", processed: false}
+
+    conn = delete conn, possible_link_path(conn, :delete, possible_link)
+    assert redirected_to(conn) == possible_link_path(conn, :show, "cabinet-office")
+    refute Repo.get(PossibleLink, possible_link.id)
+  end
+end

--- a/src/dguweb/web/controllers/possible_link_controller.ex
+++ b/src/dguweb/web/controllers/possible_link_controller.ex
@@ -1,0 +1,26 @@
+defmodule DGUWeb.PossibleLinkController do
+  use DGUWeb.Web, :controller
+
+  alias DGUWeb.{PossibleLink, Publisher}
+
+  def show(conn, %{"id" => id}) do
+    publisher = Publisher.show(conn, id)
+    render(conn, "show.html", possible_links: PossibleLink.get_for_publisher(id),
+      publisher: publisher)
+  end
+
+
+  def delete(conn, %{"id" => id}) do
+    possible_link = Repo.get!(PossibleLink, id)
+
+    pubname = possible_link.publisher_name
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    Repo.delete!(possible_link)
+
+    conn
+    |> put_flash(:info, "Possible link deleted successfully.")
+    |> redirect(to: possible_link_path(conn, :show, pubname ))
+  end
+end

--- a/src/dguweb/web/controllers/publisher_controller.ex
+++ b/src/dguweb/web/controllers/publisher_controller.ex
@@ -44,7 +44,6 @@ defmodule DGUWeb.PublisherController do
          select: count(p.id),
          where: p.publisher_name == ^publisher.name
     possible = Repo.one(query)
-    IO.inspect possible
 
     broken = DGUWeb.Report.broken_links(conn, publisher.name)
 

--- a/src/dguweb/web/helpers.ex
+++ b/src/dguweb/web/helpers.ex
@@ -5,4 +5,14 @@ defmodule DGUWeb.TemplateHelpers do
   # chars <> "..."
   def truncate_text(text), do: DGUWeb.Util.Truncation.truncate(text)
 
+  def strip_url_name(url) do
+    url
+      |> String.split("/")
+      |> Enum.reverse
+      |> hd
+      |> URI.decode
+      |> String.replace("-", " ")
+      |> String.replace("_", " ")
+  end
+
 end

--- a/src/dguweb/web/models/possible_link.ex
+++ b/src/dguweb/web/models/possible_link.ex
@@ -1,11 +1,23 @@
 defmodule DGUWeb.PossibleLink do
   use DGUWeb.Web, :model
 
+  alias DGUWeb.Repo
+
   schema "possible_links" do
     field :url, :string
     field :publisher_name, :string
+    field :processed, :boolean, default: false
 
     timestamps()
+  end
+
+  def get_for_publisher(name) do
+    Repo.all(
+      from p in __MODULE__,
+         select: p,
+         where: p.publisher_name == ^name
+    )
+
   end
 
   @doc """

--- a/src/dguweb/web/router.ex
+++ b/src/dguweb/web/router.ex
@@ -19,20 +19,20 @@ defmodule DGUWeb.Router do
 
     get "/search", SearchController, :search
 
+    resources "/possible-links", PossibleLinkController, only: [:show, :delete]
     resources "/publisher", PublisherController
     resources "/theme", ThemeController
     resources "/dataset", DatasetController
     resources "/session", SessionController, only: [:new, :create]
     resources "/upload", UploadController, only: [:new, :create, :show]
+
     post "/upload/:id/put", UploadController, :put
-    get "/upload/:id/find", UploadController, :find
-
-    get "/download/:path",  DownloadController, :download
-
-    get    "/login",  SessionController, :login_view
-    post   "/login",  SessionController, :login
-    get "/logout", SessionController, :logout
-    get "/user", UserController, :index
+    get  "/upload/:id/find", UploadController, :find
+    get  "/download/:path",  DownloadController, :download
+    get  "/login",  SessionController, :login_view
+    post "/login",  SessionController, :login
+    get  "/logout", SessionController, :logout
+    get  "/user", UserController, :index
 
     get "/fakecsv", DatasetController, :fakecsv
   end

--- a/src/dguweb/web/templates/possible_link/show.html.eex
+++ b/src/dguweb/web/templates/possible_link/show.html.eex
@@ -1,0 +1,41 @@
+<h1 class="heading-xlarge">Data links</h1>
+
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <p>
+        The list below shows links that have been found on the organisation's website, and may, or may not be Open Data.
+        </p>
+    </div>
+</div>
+
+<div class="grid-row">
+    <table>
+        <thead>
+            <th>URL</th>
+            <th>Actions</th>
+        </thead>
+        <tbody>
+            <%= for pl <- @possible_links do %>
+            <tr>
+                <td>
+                    <a href="<%= pl.url %>" target="_blank">
+                        <%= pl.url |> strip_url_name |> truncate_text %>
+                    </a>
+                </td>
+                <td class="font-xsmall">
+                    <a href="">Add to dataset</a>
+                    <a href="">New dataset</a>
+                    <a href="">Remove</a>
+                </td>
+            </tr>
+            <% end %>
+        </tbody>
+    </table>
+</div>
+
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <br/>
+        <a class="button" href="<%= publisher_path(@conn, :show, @publisher.name) %>" role="button">Back to '<%= @publisher.title %>'</a>
+    </div>
+</div>

--- a/src/dguweb/web/templates/publisher/show.html.eex
+++ b/src/dguweb/web/templates/publisher/show.html.eex
@@ -59,7 +59,7 @@
         <div class="grid-row">
           <div class="column-two-thirds">
             <div class="data">
-              <h2 class="bold-xxlarge"><a href="#datasets"><%= @possible %></a></h2>
+              <h2 class="bold-xxlarge"><a href="<%= possible_link_path(@conn, :show, @publisher.name) %>"><%= @possible %></a></h2>
               <p class="bold-xsmall"><%= gettext("Possible Open Data resources found on website") %></p>
             </div>
           </div>

--- a/src/dguweb/web/views/possible_link_view.ex
+++ b/src/dguweb/web/views/possible_link_view.ex
@@ -1,0 +1,3 @@
+defmodule DGUWeb.PossibleLinkView do
+  use DGUWeb.Web, :view
+end


### PR DESCRIPTION
The newly added page just shows the links and allows the user to open
and review them before deciding whether to ignore it, or add it to a
dataset, or even a new one.

UI is most likely not right (links in a table, shocking) but mostly just for show right now.
